### PR TITLE
Feat: Chip 컴포넌트 UI 구현

### DIFF
--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -1,0 +1,40 @@
+import { MouseEvent } from "react";
+import DESIGN_TOKEN from "@/styles/tokens";
+import styled, { CSSProperties } from "styled-components";
+
+interface DefaultChipProps {
+  label: string;
+  isSelected?: boolean;
+  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  style?: DefaultChipContainerStyleProps;
+  selectedStyle?: DefaultChipContainerStyleProps;
+}
+
+export default function DefaultChip({ label, isSelected, onClick, style, selectedStyle }: DefaultChipProps) {
+  const currentStyle = isSelected ? selectedStyle : style;
+  return (
+    <DefaultChipContainer {...currentStyle} onClick={onClick}>
+      {label}
+    </DefaultChipContainer>
+  );
+}
+
+interface DefaultChipContainerStyleProps {
+  $padding?: CSSProperties["padding"];
+  $backgroundColor?: CSSProperties["backgroundColor"];
+  $fontColor?: CSSProperties["color"];
+  $borderRadius?: CSSProperties["borderRadius"];
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const DefaultChipContainer = styled.div<DefaultChipContainerStyleProps>`
+  width: fit-content;
+  padding: ${({ $padding }) => $padding || `0.4rem 1.2rem`};
+
+  background-color: ${({ $backgroundColor }) => $backgroundColor || color.gray[300]};
+  color: ${({ $fontColor }) => $fontColor || color.black[300]};
+  border-radius: ${({ $borderRadius }) => $borderRadius || `9999rem`};
+
+  ${typography.font12Semibold}
+`;

--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -13,13 +13,13 @@ interface DefaultChipProps {
 export default function DefaultChip({ label, isSelected, onClick, style, selectedStyle }: DefaultChipProps) {
   const currentStyle = isSelected ? selectedStyle : style;
   return (
-    <DefaultChipContainer {...currentStyle} onClick={onClick}>
+    <Container {...currentStyle} onClick={onClick}>
       {label}
-    </DefaultChipContainer>
+    </Container>
   );
 }
 
-interface DefaultChipContainerStyleProps {
+export interface DefaultChipContainerStyleProps {
   $padding?: CSSProperties["padding"];
   $backgroundColor?: CSSProperties["backgroundColor"];
   $fontColor?: CSSProperties["color"];
@@ -28,7 +28,7 @@ interface DefaultChipContainerStyleProps {
 
 const { color, typography } = DESIGN_TOKEN;
 
-const DefaultChipContainer = styled.div<DefaultChipContainerStyleProps>`
+const Container = styled.div<DefaultChipContainerStyleProps>`
   width: fit-content;
   padding: ${({ $padding }) => $padding || `0.4rem 1.2rem`};
 

--- a/co-kkiri/src/components/commons/Chips/PositionChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/PositionChip.tsx
@@ -1,0 +1,9 @@
+import DefaultChip from "./DefaultChip";
+
+interface PositionChipProps {
+  label: string;
+}
+
+export default function PositionChip({ label }: PositionChipProps) {
+  return <DefaultChip label={label} />;
+}

--- a/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
@@ -1,0 +1,27 @@
+import DefaultChip, { DefaultChipContainerStyleProps } from "./DefaultChip";
+
+interface ProjectChipProps {
+  label: "스터디" | "프로젝트"; //나중에 global한 type으로 빼내어야함
+}
+
+const ProjectChipStyle: DefaultChipContainerStyleProps = {
+  $padding: `.6rem 3rem`,
+  $borderRadius: `.2rem 6.1rem 6.1rem .2rem`,
+};
+
+const studyProjectChipStyle: DefaultChipContainerStyleProps = {
+  $backgroundColor: `#DAF4AF`,
+  $fontColor: `#588F00`,
+  ...ProjectChipStyle,
+};
+
+const projectProjectChipStyle: DefaultChipContainerStyleProps = {
+  $backgroundColor: `#FFDBE4`,
+  $fontColor: `#C71B44`,
+  ...ProjectChipStyle,
+};
+
+export default function ProjectChip({ label }: ProjectChipProps) {
+  const projectChipStyle = label === "스터디" ? studyProjectChipStyle : projectProjectChipStyle;
+  return <DefaultChip label={label} style={projectChipStyle} />;
+}


### PR DESCRIPTION
### 📌요구사항
- [x] Chip 컴포넌트 UI 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- DefaultChip 구현
- DefaultChip에서 파생된 PositionChip 및 ProjectChip 구현

### <DefaultChip>
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/96b06e8a-f5f5-4e35-87d8-ddb9ff0ee8aa)
- Container의 Style을 interface로 정의하여 직접 내려줄 수 있음 (내리지 않아도 기본값 제공)
```
export interface DefaultChipContainerStyleProps {
  $padding?: CSSProperties["padding"];
  $backgroundColor?: CSSProperties["backgroundColor"];
  $fontColor?: CSSProperties["color"];
  $borderRadius?: CSSProperties["borderRadius"];
}
```

### <PositionChip>
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/f2e1775d-abfc-4f69-8bae-d68e27abec79)
- Position을 표시하는 Chip
- DefaultChip에 style을 전달하지 않은 기본모양과 같음

### <ProjectChip>
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/8fbda42c-f15e-408e-ba27-cf4db2e3ba2e)
- Project의 분류를 표시하는 Chip
- 기본틀에서 추가적인 style 적용

### 📌스크린샷 / 테스트결과 (선택)
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/b4e74213-6841-4119-bd47-5f5f5652a008)

### 테스트 코드
```
    <>
      <h3>DefaultChip</h3>
      <DefaultChip label="반갑습니다" />
      <h3>PositionChip</h3>
      <PositionChip label="프론트엔드" />
      <h3>ProjectChip</h3>
      <ProjectChip label="스터디" />
      <ProjectChip label="프로젝트" />
    </>
```

### 📌이슈 번호
Closes: #11 