### PR TITLE
Feat: home, study list 페이지에 사용되는 카드 컴포넌트 제작

### DIFF
--- a/co-kkiri/src/components/commons/Card/Card.styled.ts
+++ b/co-kkiri/src/components/commons/Card/Card.styled.ts
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+type PageProp = {
+  $page: string;
+};
+
+interface ContainerProps extends PageProp {
+  $isSidebarOpen: boolean;
+}
+
+const {
+  color,
+  boxShadow: { content },
+  mediaQueries: { desktop },
+  mediaQueries: { tablet },
+  mediaQueries: { mobile },
+} = DESIGN_TOKEN;
+
+export const Container = styled.article<ContainerProps>`
+  ${({ $page, $isSidebarOpen }) =>
+    $page === "home" && `${desktop} { width: ${$isSidebarOpen && "44.5rem"}; } ${tablet} { width: 34.6rem; }`};
+  ${({ $page, $isSidebarOpen }) =>
+    $page === "studyList" &&
+    `${desktop} { width: ${$isSidebarOpen && "29rem"}; } ${tablet} { width: 34.6rem; } ${mobile}{width: 32rem}`};
+  width: 26.5rem;
+  border-radius: 2.2rem;
+  box-shadow: ${content};
+`;
+
+export const TypeWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  padding: 1.5rem 2rem 0 0;
+`;
+
+export const UpperBox = styled.div<PageProp>`
+  ${({ $page }) => $page === "home" && `padding: 1rem 2rem 1.8rem;`};
+  ${({ $page }) => $page === "studyList" && `padding: 0.5rem 2rem 1.5rem;`};
+`;
+
+export const HeaderWrapper = styled.header<PageProp>`
+  ${({ $page }) => $page === "home" && `padding-bottom: 0.8rem;`};
+  ${({ $page }) => $page === "studyList" && `padding-bottom: 1.2rem;`};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const HeaderPadding = styled.div<PageProp>`
+  ${({ $page }) => $page === "home" && `padding-top: 1rem; padding-bottom: 0.4rem;`};
+`;
+
+export const ContentWrapper = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const BreakLine = styled.div`
+  background-color: ${color.gray[3]};
+  height: 0.1rem;
+  width: 100%;
+`;
+
+export const FooterBox = styled.footer`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.6rem 2rem;
+`;
+
+export const CountWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+`;

--- a/co-kkiri/src/components/commons/Card/Count.tsx
+++ b/co-kkiri/src/components/commons/Card/Count.tsx
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+//임시
+interface CountProps {
+  icon: { src: string; alt: string };
+  count: number;
+}
+
+export default function Count({ icon, count }: CountProps) {
+  return (
+    <Wrapper>
+      <img src={icon.src} alt={icon.alt} />
+      <span>{count}</span>
+    </Wrapper>
+  );
+}
+
+const {
+  color,
+  typography: { font12Semibold },
+} = DESIGN_TOKEN;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+
+  img {
+    width: 2.4rem;
+  }
+
+  span {
+    ${font12Semibold};
+    color: ${color.gray[1]};
+  }
+`;

--- a/co-kkiri/src/components/commons/Card/Header.tsx
+++ b/co-kkiri/src/components/commons/Card/Header.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+//임시
+interface HeaderProps {
+  deadline: string;
+  progressWay: string;
+}
+
+export default function Header({ deadline, progressWay }: HeaderProps) {
+  return (
+    <Container>
+      <span>{`${deadline} 마감`}</span>
+      <div></div>
+      <span>{progressWay}</span>
+    </Container>
+  );
+}
+
+const {
+  color,
+  typography: { font12Semibold },
+} = DESIGN_TOKEN;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  span {
+    ${font12Semibold}
+    color: ${color.black[3]}
+  }
+
+  div {
+    width: 0.1rem;
+    height: 0.8rem;
+    background-color: ${color.black[3]};
+  }
+`;

--- a/co-kkiri/src/components/commons/Card/Positions.tsx
+++ b/co-kkiri/src/components/commons/Card/Positions.tsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import PositionChip from "../Chips/PositionChip";
+
+// 임시
+interface Position {
+  id: number;
+  name: string;
+}
+
+interface PositionsProps {
+  position: Position[];
+}
+
+export default function Positions({ position }: PositionsProps) {
+  return (
+    <Wrapper>
+      {position.map((item) => (
+        <div key={item.id}>
+          <PositionChip label={item.name} />
+        </div>
+      ))}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 0.6rem;
+`;

--- a/co-kkiri/src/components/commons/Card/Scrap.tsx
+++ b/co-kkiri/src/components/commons/Card/Scrap.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+import { ICONS } from "@/constants/icons";
+
+//임시
+interface ScrapProps {
+  scrap: boolean;
+  size: number;
+}
+
+export default function Scrap({ scrap, size }: ScrapProps) {
+  const scrapIcon = scrap ? ICONS.scrapFull : ICONS.scrapEmpty;
+
+  return (
+    <Wrapper $size={size}>
+      <img src={scrapIcon.src} alt={scrapIcon.alt} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div<{ $size: number }>`
+  width: ${({ $size }) => $size}rem;
+  img {
+    width: 100%;
+  }
+`;

--- a/co-kkiri/src/components/commons/Card/Stacks.tsx
+++ b/co-kkiri/src/components/commons/Card/Stacks.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+//임시
+interface Stack {
+  id: number;
+  img: string;
+}
+
+interface StacksProps {
+  stack: Stack[];
+}
+
+export default function Stacks({ stack }: StacksProps) {
+  return (
+    <Wrapper>
+      {stack.map((item) => (
+        <Background key={item.id}></Background>
+      ))}
+    </Wrapper>
+  );
+}
+
+const { color } = DESIGN_TOKEN;
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 0.6rem;
+`;
+
+const Background = styled.div`
+  background-color: ${color.gray[3]};
+  border-radius: 50%;
+  width: 3.6rem;
+  height: 3.6rem;
+`;

--- a/co-kkiri/src/components/commons/Card/Title.tsx
+++ b/co-kkiri/src/components/commons/Card/Title.tsx
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+//임시
+interface TitleProps {
+  title: string;
+}
+
+export default function Title({ title }: TitleProps) {
+  return <CardTitle>{title}</CardTitle>;
+}
+
+const {
+  color,
+  typography: { font16Bold },
+} = DESIGN_TOKEN;
+
+const CardTitle = styled.h1`
+  ${font16Bold}
+  color: ${color.black[1]};
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/co-kkiri/src/components/commons/Card/index.tsx
+++ b/co-kkiri/src/components/commons/Card/index.tsx
@@ -1,0 +1,78 @@
+import * as S from "./Card.styled";
+import Header from "./Header";
+import ProjectChip from "../Chips/ProjectChip";
+import Scrap from "./Scrap";
+import Title from "./Title";
+import Positions from "./Positions";
+import Stacks from "./Stacks";
+import Count from "./Count";
+import { ICONS } from "@/constants/icons";
+
+// 임시
+interface Position {
+  id: number;
+  name: string;
+}
+
+//임시
+interface Stack {
+  id: number;
+  img: string;
+}
+
+//임시
+interface CardData {
+  type: "스터디" | "프로젝트";
+  scrap: boolean;
+  recruitEndAt: string;
+  progressWay: string;
+  title: string;
+  position: Position[];
+  stack: Stack[];
+  user: { nickname: string; profileImage: null | string };
+  viewCount: number;
+  commentCount: number;
+}
+
+interface CardProps {
+  page: "home" | "studyList";
+  cardData: CardData;
+  isSidebarOpen: boolean;
+}
+
+export default function Card({ page, isSidebarOpen, cardData }: CardProps) {
+  const { type, scrap, recruitEndAt, progressWay, title, position, stack, user, viewCount, commentCount } = cardData;
+
+  return (
+    <S.Container $page={page} $isSidebarOpen={isSidebarOpen}>
+      {page === "studyList" && (
+        <S.TypeWrapper>
+          <ProjectChip label={type} />
+          <Scrap scrap={scrap} size={3.6} />
+        </S.TypeWrapper>
+      )}
+      <S.UpperBox $page={page}>
+        <S.HeaderWrapper $page={page}>
+          <S.HeaderPadding $page={page}>
+            <Header deadline={recruitEndAt} progressWay={progressWay} />
+          </S.HeaderPadding>
+          {page === "home" && <Scrap scrap={scrap} size={2.8} />}
+        </S.HeaderWrapper>
+        <S.ContentWrapper>
+          <Title title={title} />
+          <Positions position={position} />
+          {page === "studyList" && <Stacks stack={stack} />}
+        </S.ContentWrapper>
+      </S.UpperBox>
+      <S.BreakLine />
+      <S.FooterBox>
+        {/* UserInfo 컴포넌트로 대체 */}
+        <div style={{ height: 36 }}>코끼리</div>
+        <S.CountWrapper>
+          <Count icon={ICONS.eye} count={viewCount} />
+          <Count icon={ICONS.comment} count={commentCount} />
+        </S.CountWrapper>
+      </S.FooterBox>
+    </S.Container>
+  );
+}


### PR DESCRIPTION
### 📌요구사항
- [x] home 페이지와 studyList 페이지에 사용될 카드 컴포넌트 제작하기

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

- 임시 mock 데이터 작성
```js
// /src/pages/Home.tsx
import Card from "@/components/commons/Card";

const cardData = {
  type: "스터디",
  scrap: true,
  recruitEndAt: "2024.3.3",
  progressWay: "온라인",
  title:
    "실제 사용할 쇼핑몰 웹프로젝트 만들어나가실 분 구합니다. 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 쇼핑몰 사장 ",
  position: [
    { id: 0, name: "프론트엔드" },
    { id: 1, name: "백엔드" },
    { id: 2, name: "디자이너" },
  ],
  stack: [
    { id: 0, img: "" },
    { id: 1, img: "" },
    { id: 2, img: "" },
  ],
  user: { nickname: "코끼리", profileImage: null },
  viewCount: 10,
  commentCount: 24,
};

export default function Home() {
  return <Card page="studyList" isSidebarOpen={true} cardData={cardData} />;
}

```
- page정보, 사이드바 열림 정보, 카드 데이터를 prop으로 넘겨줌
- 카드 컴포넌트를 구성할 세부 컴포넌트를 나누고 구현함
- page정보에 따라 달라지는 세부 컴포넌트를 조건부 렌더링으로 구현함
- 사이드바 열림 정보 및 화면 크기에 따른 반응형 구현
- 카드 border-radius 값을 모르겠음(일단 2.2rem으로 적용함)

### 📌스크린샷 / 테스트결과 (선택)
- home 페이지, 데스크탑 사이즈, 사이드바 열렸을 경우
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/d3d50c97-653b-4581-9dba-bb7139950e0e)

- home 페이지, 반응형, 사이드바 닫혔을 경우

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/6a61cb01-d648-4004-a6bf-d80cac1209c9

- studyList 페이지, 데스크탑 사이즈, 사이드바 열렸을 경우
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/4e8393d5-dc5d-454c-a332-3616b9c3722b)

- studyList 페이지, 반응형, 사이드바 닫혔을 경우

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/0aa1b87e-5bf2-4ef3-a7a6-9a82d40af880

### 📌이슈 번호
close #17
