### PR TITLE
Feat: navigation layout 구현

### DIFF
--- a/co-kkiri/index.html
+++ b/co-kkiri/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/co-kkiri/src/PageRouter.tsx
+++ b/co-kkiri/src/PageRouter.tsx
@@ -12,6 +12,7 @@ import Manage from "@/pages/Manage";
 import MyStudy from "@/pages/MyStudy";
 import Profile from "@/pages/Profile";
 import { ROUTER_PATH } from "@/lib/path";
+import Navigation from "./layouts/Navigation";
 
 const {
   HOME_PATH,
@@ -30,6 +31,7 @@ const {
 const PageRouter = () => {
   return (
     <Router>
+      <Navigation />
       <Routes>
         <Route path={HOME_PATH} element={<Home />} />
         <Route path={STUDY_LIST_PATH} element={<StudyList />} />

--- a/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
+++ b/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
 
-const { color, typography, mediaQueries, zIndex } = DESIGN_TOKEN;
+const { color, typography, mediaQueries } = DESIGN_TOKEN;
 
 export const Container = styled.div`
   background-color: ${color.white};

--- a/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
+++ b/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
@@ -4,8 +4,6 @@ import DESIGN_TOKEN from "@/styles/tokens";
 const { color, typography, mediaQueries, zIndex } = DESIGN_TOKEN;
 
 export const Container = styled.div`
-  ${zIndex.sticky};
-  position: sticky;
   background-color: ${color.white};
   width: 100%;
   display: flex;

--- a/co-kkiri/src/components/commons/Gnb/index.tsx
+++ b/co-kkiri/src/components/commons/Gnb/index.tsx
@@ -4,23 +4,29 @@ import { ICONS } from "@/constants/icons";
 import { IMAGES } from "@/constants/images";
 import { Link } from "react-router-dom";
 import UserInfo from "../UserInfo";
+import { useState } from "react";
+import AuthModal from "@/components/modals/AuthModal";
 
 interface GnbProps {
   user?: {
     nickname: string;
     profileImage: string;
   }; // 미정
-  onCategoryClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  onLoginClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  onSignupClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onSideBarClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function Gnb({ user, onCategoryClick, onLoginClick, onSignupClick }: GnbProps) {
+export default function Gnb({ user, onSideBarClick }: GnbProps) {
   const { HOME_PATH, POST_PATH } = ROUTER_PATH;
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+
+  const handleAuthModalOpen = () => {
+    setIsAuthModalOpen(!isAuthModalOpen);
+  };
+
   return (
     <S.Container>
       <S.LeftGroupBox>
-        <button onClick={onCategoryClick}>
+        <button onClick={onSideBarClick}>
           <img src={ICONS.category.src} alt={ICONS.category.alt} />
         </button>
         <Link to={HOME_PATH}>
@@ -31,15 +37,9 @@ export default function Gnb({ user, onCategoryClick, onLoginClick, onSignupClick
         <Link to={POST_PATH}>
           <S.PostButton>스터디 모집하기</S.PostButton>
         </Link>
-        {user ? (
-          <UserInfo user={user} />
-        ) : (
-          <div>
-            <S.SignButton onClick={onLoginClick}>로그인</S.SignButton>/
-            <S.SignButton onClick={onSignupClick}>회원가입</S.SignButton>
-          </div>
-        )}
+        {user ? <UserInfo user={user} /> : <S.SignButton onClick={handleAuthModalOpen}>로그인/회원가입</S.SignButton>}
       </S.RightGroupBox>
+      {isAuthModalOpen && <AuthModal onClick={handleAuthModalOpen} />}
     </S.Container>
   );
 }

--- a/co-kkiri/src/components/commons/SideBar/SideBar.styled.ts
+++ b/co-kkiri/src/components/commons/SideBar/SideBar.styled.ts
@@ -4,9 +4,9 @@ import styled from "styled-components";
 const { boxShadow, color, typography, mediaQueries, overlayBackDropColor } = DESIGN_TOKEN;
 
 export const Background = styled.div`
+  position: fixed;
   width: 100%;
   height: 100vh;
-  background-color: none;
 
   ${mediaQueries.tablet} {
     background-color: ${overlayBackDropColor};
@@ -19,7 +19,7 @@ export const Background = styled.div`
 
 export const Container = styled.div`
   width: 21rem;
-  height: 63rem;
+  height: 98vh;
   box-shadow: ${boxShadow.content};
   border-top-right-radius: 1.5rem;
   border-bottom-right-radius: 1.5rem;
@@ -53,19 +53,17 @@ export const CategoryBox = styled.div`
   padding-top: 3rem;
 `;
 
-export const Category = styled.div`
+export const Category = styled.button`
   background-color: ${color.white};
-  cursor: pointer;
 
   &:hover {
     color: ${color.primary[1]};
   }
 `;
 
-export const HamburgerMenuWrapper = styled.div`
+export const HamburgerMenuWrapper = styled.button`
   padding-top: 2.8rem;
   display: none;
-  cursor: pointer;
 
   ${mediaQueries.tablet} {
     display: block;

--- a/co-kkiri/src/components/commons/SideBar/SideBar.styled.ts
+++ b/co-kkiri/src/components/commons/SideBar/SideBar.styled.ts
@@ -19,7 +19,7 @@ export const Background = styled.div`
 
 export const Container = styled.div`
   width: 21rem;
-  height: 98vh;
+  height: 80vh;
   box-shadow: ${boxShadow.content};
   border-top-right-radius: 1.5rem;
   border-bottom-right-radius: 1.5rem;

--- a/co-kkiri/src/components/commons/SideBar/index.tsx
+++ b/co-kkiri/src/components/commons/SideBar/index.tsx
@@ -2,25 +2,30 @@ import { ICONS } from "@/constants/icons";
 import { Link } from "react-router-dom";
 import { ROUTER_PATH } from "@/lib/path";
 import * as S from "./SideBar.styled";
+import React from "react";
 
-export default function SideBar() {
+interface SideBarProps {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function SideBar({ onClick }: SideBarProps) {
   const { HOME_PATH, STUDY_LIST_PATH, CASTING } = ROUTER_PATH;
 
   return (
     <S.Background>
       <S.Container>
-        <S.HamburgerMenuWrapper>
+        <S.HamburgerMenuWrapper onClick={onClick}>
           <img src={ICONS.category.src} alt={ICONS.category.alt} />
         </S.HamburgerMenuWrapper>
         <S.CategoryBox>
           <Link to={HOME_PATH}>
-            <S.Category>홈</S.Category>
+            <S.Category onClick={onClick}>홈</S.Category>
           </Link>
           <Link to={STUDY_LIST_PATH}>
-            <S.Category>스터디/프로젝트 찾기</S.Category>
+            <S.Category onClick={onClick}>스터디/프로젝트 찾기</S.Category>
           </Link>
           <Link to={CASTING}>
-            <S.Category>스카우트</S.Category>
+            <S.Category onClick={onClick}>스카우트</S.Category>
           </Link>
         </S.CategoryBox>
       </S.Container>

--- a/co-kkiri/src/components/commons/UserInfo.tsx
+++ b/co-kkiri/src/components/commons/UserInfo.tsx
@@ -1,7 +1,5 @@
 import { IMAGES } from "@/constants/images";
-import { ROUTER_PATH } from "@/lib/path";
 import DESIGN_TOKEN from "@/styles/tokens";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 interface UserInfoProps {
@@ -12,7 +10,6 @@ interface UserInfoProps {
 }
 
 export default function UserInfo({ user }: UserInfoProps) {
-  const { MY_PAGE } = ROUTER_PATH;
   return (
     <UserInfoWrapper>
       {user.profileImage ? (
@@ -20,9 +17,7 @@ export default function UserInfo({ user }: UserInfoProps) {
       ) : (
         <img src={IMAGES.profileImg.src} alt={IMAGES.profileImg.alt} />
       )}
-      <Link to={MY_PAGE}>
-        <Nickname>{user.nickname}</Nickname>
-      </Link>
+      <Nickname>{user.nickname}</Nickname>
     </UserInfoWrapper>
   );
 }

--- a/co-kkiri/src/components/modals/AuthModal.tsx
+++ b/co-kkiri/src/components/modals/AuthModal.tsx
@@ -5,11 +5,15 @@ import { IMAGES } from "@/constants/images";
 import { Link } from "react-router-dom";
 import { ROUTER_PATH } from "@/lib/path";
 
-export default function AuthModal() {
+interface AuthModalProps {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function AuthModal({ onClick }: AuthModalProps) {
   const { HOME_PATH } = ROUTER_PATH;
 
   return (
-    <ModalLayout desktopWidth={558} mobileWidth={320}>
+    <ModalLayout desktopWidth={558} mobileWidth={320} onClick={onClick}>
       <Container>
         <Link to={HOME_PATH}>
           <Logo src={IMAGES.logo.src} alt={IMAGES.logo.src} />

--- a/co-kkiri/src/components/modals/AuthModal.tsx
+++ b/co-kkiri/src/components/modals/AuthModal.tsx
@@ -20,10 +20,10 @@ export default function AuthModal({ onClick }: AuthModalProps) {
         </Link>
         <span>로그인 / 회원가입</span>
         <LoginButtonBox>
-          <LoginButton padding={0.9}>
+          <LoginButton $padding={0.9}>
             <img src={IMAGES.googleLogo.src} alt={IMAGES.googleLogo.alt} />
           </LoginButton>
-          <LoginButton padding={1.3}>
+          <LoginButton $padding={1.3}>
             <img src={IMAGES.githubLogo.src} alt={IMAGES.githubLogo.alt} />
           </LoginButton>
         </LoginButtonBox>
@@ -68,7 +68,7 @@ const LoginButtonBox = styled.div`
   }
 `;
 
-const LoginButton = styled.div<{ padding: number }>`
+const LoginButton = styled.div<{ $padding: number }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -81,6 +81,6 @@ const LoginButton = styled.div<{ padding: number }>`
   ${mediaQueries.mobile} {
     width: 5.6rem;
     height: 5.6rem;
-    padding: ${(props) => props.padding}rem;
+    padding: ${(props) => props.$padding}rem;
   }
 `;

--- a/co-kkiri/src/components/modals/ModalLayout.tsx
+++ b/co-kkiri/src/components/modals/ModalLayout.tsx
@@ -1,28 +1,37 @@
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 import close from "@/assets/icons/close.svg";
+import ModalPortal from "./ModalPortal";
 
 interface ModalLayoutProps {
   children: React.ReactNode;
   mobileWidth?: number;
   tabletWidth?: number;
   desktopWidth: number;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function ModalLayout({ children, mobileWidth, tabletWidth, desktopWidth }: ModalLayoutProps) {
+export default function ModalLayout({ children, mobileWidth, tabletWidth, desktopWidth, onClick }: ModalLayoutProps) {
   return (
-    <Container>
-      <ModalBox mobileWidth={mobileWidth} tabletWidth={tabletWidth} desktopWidth={desktopWidth}>
-        <CloseButton src={close} alt="닫기 아이콘" />
-        {children}
-      </ModalBox>
-    </Container>
+    <ModalPortal>
+      <Container>
+        <ModalBox mobileWidth={mobileWidth} tabletWidth={tabletWidth} desktopWidth={desktopWidth}>
+          <CloseButton onClick={onClick}>
+            <img src={close} alt="닫기 아이콘" />
+          </CloseButton>
+          {children}
+        </ModalBox>
+      </Container>
+    </ModalPortal>
   );
 }
 
 const { color, overlayBackDropColor, mediaQueries } = DESIGN_TOKEN;
 
 const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -51,7 +60,7 @@ const ModalBox = styled.div<ModalLayoutProps>`
   }
 `;
 
-const CloseButton = styled.img`
+const CloseButton = styled.button`
   margin-left: auto;
   width: 1.2rem;
   height: 1.2rem;

--- a/co-kkiri/src/components/modals/ModalLayout.tsx
+++ b/co-kkiri/src/components/modals/ModalLayout.tsx
@@ -4,15 +4,18 @@ import close from "@/assets/icons/close.svg";
 import ModalPortal from "./ModalPortal";
 
 interface ModalBoxProps {
-  mobileWidth?: number;
-  tabletWidth?: number;
-  desktopWidth: number;
+  $mobileWidth?: number;
+  $tabletWidth?: number;
+  $desktopWidth: number;
 }
 
-interface ModalLayoutProps extends ModalBoxProps {
+interface ModalLayoutProps {
   children: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   modalType?: "confirm";
+  mobileWidth?: number;
+  tabletWidth?: number;
+  desktopWidth: number;
 }
 
 export default function ModalLayout({
@@ -26,7 +29,7 @@ export default function ModalLayout({
   return (
     <ModalPortal>
       <Container>
-        <ModalBox mobileWidth={mobileWidth} tabletWidth={tabletWidth} desktopWidth={desktopWidth}>
+        <ModalBox $mobileWidth={mobileWidth} $tabletWidth={tabletWidth} $desktopWidth={desktopWidth}>
           {!modalType && "confirm" && (
             <CloseButton onClick={onClick}>
               <img src={close} alt="닫기 아이콘" />
@@ -59,17 +62,17 @@ const ModalBox = styled.div<ModalBoxProps>`
   align-items: center;
   flex-direction: column;
   gap: 2.2rem;
-  width: ${(props) => props.desktopWidth / 10}rem;
+  width: ${(props) => props.$desktopWidth / 10}rem;
   height: auto;
   background-color: ${color.white};
   border-radius: 2rem;
 
   ${mediaQueries.tablet} {
-    width: ${(props) => props.tabletWidth && `${props.tabletWidth / 10}rem`};
+    width: ${(props) => props.$tabletWidth && `${props.$tabletWidth / 10}rem`};
   }
 
   ${mediaQueries.mobile} {
-    width: ${(props) => props.mobileWidth && `${props.mobileWidth / 10}rem`};
+    width: ${(props) => props.$mobileWidth && `${props.$mobileWidth / 10}rem`};
   }
 `;
 

--- a/co-kkiri/src/components/modals/ModalLayout.tsx
+++ b/co-kkiri/src/components/modals/ModalLayout.tsx
@@ -3,22 +3,35 @@ import styled from "styled-components";
 import close from "@/assets/icons/close.svg";
 import ModalPortal from "./ModalPortal";
 
-interface ModalLayoutProps {
-  children: React.ReactNode;
+interface ModalBoxProps {
   mobileWidth?: number;
   tabletWidth?: number;
   desktopWidth: number;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function ModalLayout({ children, mobileWidth, tabletWidth, desktopWidth, onClick }: ModalLayoutProps) {
+interface ModalLayoutProps extends ModalBoxProps {
+  children: React.ReactNode;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  modalType?: "confirm";
+}
+
+export default function ModalLayout({
+  mobileWidth,
+  tabletWidth,
+  desktopWidth,
+  children,
+  onClick,
+  modalType,
+}: ModalLayoutProps) {
   return (
     <ModalPortal>
       <Container>
         <ModalBox mobileWidth={mobileWidth} tabletWidth={tabletWidth} desktopWidth={desktopWidth}>
-          <CloseButton onClick={onClick}>
-            <img src={close} alt="닫기 아이콘" />
-          </CloseButton>
+          {!modalType && "confirm" && (
+            <CloseButton onClick={onClick}>
+              <img src={close} alt="닫기 아이콘" />
+            </CloseButton>
+          )}
           {children}
         </ModalBox>
       </Container>
@@ -40,7 +53,7 @@ const Container = styled.div`
   background-color: ${overlayBackDropColor};
 `;
 
-const ModalBox = styled.div<ModalLayoutProps>`
+const ModalBox = styled.div<ModalBoxProps>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -29,14 +29,13 @@ interface SideBarWrapperProps {
 
 const SideBarWrapper = styled.div<SideBarWrapperProps>`
   ${mediaQueries.desktop} {
-    transition: transform 0.3s ease-in-out;
+    transition: transform 0.5s ease-in-out;
     transform: ${(props) => (props.$isOpen ? "translateX(0)" : "translateX(-100%)")};
   }
   ${mediaQueries.tablet} {
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 100;
     display: ${(props) => (props.$isOpen ? "block" : "none")};
   }
 

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -14,7 +14,7 @@ export default function Navigation() {
   return (
     <>
       <Gnb onSideBarClick={handleSideBarOpen} />
-      <SideBarWrapper isOpen={isCategoryOpen}>
+      <SideBarWrapper $isOpen={isCategoryOpen}>
         <SideBar onClick={handleSideBarOpen} />
       </SideBarWrapper>
     </>
@@ -24,26 +24,26 @@ export default function Navigation() {
 const { mediaQueries } = DESIGN_TOKEN;
 
 interface SideBarWrapperProps {
-  isOpen: boolean;
+  $isOpen: boolean;
 }
 
 const SideBarWrapper = styled.div<SideBarWrapperProps>`
   ${mediaQueries.desktop} {
     transition: transform 0.3s ease-in-out;
-    transform: ${(props) => (props.isOpen ? "translateX(0)" : "translateX(-100%)")};
+    transform: ${(props) => (props.$isOpen ? "translateX(0)" : "translateX(-100%)")};
   }
   ${mediaQueries.tablet} {
     position: absolute;
     top: 0;
     left: 0;
     z-index: 100;
-    display: ${(props) => (props.isOpen ? "block" : "none")};
+    display: ${(props) => (props.$isOpen ? "block" : "none")};
   }
 
   ${mediaQueries.mobile} {
     position: absolute;
     top: 0;
     left: 0;
-    display: ${(props) => (props.isOpen ? "block" : "none")};
+    display: ${(props) => (props.$isOpen ? "block" : "none")};
   }
 `;

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -1,0 +1,49 @@
+import Gnb from "@/components/commons/Gnb";
+import SideBar from "@/components/commons/SideBar";
+import DESIGN_TOKEN from "@/styles/tokens";
+import { useState } from "react";
+import styled from "styled-components";
+
+export default function Navigation() {
+  const [isCategoryOpen, setIsCategoryOpen] = useState<boolean>(false);
+
+  const handleSideBarOpen = () => {
+    setIsCategoryOpen(!isCategoryOpen);
+  };
+
+  return (
+    <>
+      <Gnb onSideBarClick={handleSideBarOpen} />
+      <SideBarWrapper isOpen={isCategoryOpen}>
+        <SideBar onClick={handleSideBarOpen} />
+      </SideBarWrapper>
+    </>
+  );
+}
+
+const { mediaQueries } = DESIGN_TOKEN;
+
+interface SideBarWrapperProps {
+  isOpen: boolean;
+}
+
+const SideBarWrapper = styled.div<SideBarWrapperProps>`
+  ${mediaQueries.desktop} {
+    transition: transform 0.3s ease-in-out;
+    transform: ${(props) => (props.isOpen ? "translateX(0)" : "translateX(-100%)")};
+  }
+  ${mediaQueries.tablet} {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 100;
+    display: ${(props) => (props.isOpen ? "block" : "none")};
+  }
+
+  ${mediaQueries.mobile} {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: ${(props) => (props.isOpen ? "block" : "none")};
+  }
+`;


### PR DESCRIPTION
### 📌요구사항
- [x] Navigation layout 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- index.html에 ModalPortal 적용, ModalLayout에 ModalPortal 추가
- Gnb 수정
  1. 로그인/회원가입 클릭 시, AuthModal open 기능 추가
  2. SideBar 기능을 위한 prop 추가
- SideBar 수정
  1. HamburgerMenu 버튼 onClick 기능 추가
  2. 각 목록 버튼 누르면 링크 이동 후 SideBar 닫히도록 기능 추가
- ModalLayout에 modalType 추가하여 닫기 버튼 유/무 기능 추가
- (해결 못함) 모달이 열렸을 때, 밑 부분까지 채워지지 않는 이슈
- (사이드바를 모달로 할까...굳이..?) 
- (다음부터는 JSDoc 사용해 볼 수 있도록...!)

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/f3c9f519-e394-4ae1-bdbe-5669aecf99df



### 📌이슈 번호
close #40