### PR TITLE
Feat: ConfirmModal 컴포넌트 UI 구현

### DIFF
--- a/co-kkiri/src/components/modals/ConfirmModal.tsx
+++ b/co-kkiri/src/components/modals/ConfirmModal.tsx
@@ -1,0 +1,64 @@
+import styled from "styled-components";
+import ModalLayout from "./ModalLayout";
+import Button from "../commons/Button";
+import DESIGN_TOKEN from "@/styles/tokens";
+import { CONFIRM_TYPE } from "@/constants/modal";
+
+type ConfirmType = "apply" | "post" | "modify" | "delete" | "cancel" | "review" | "start" | "accept" | "refuse";
+
+interface ConfirmModalProps {
+  type: ConfirmType;
+}
+
+export default function ConfirmModal({ type }: ConfirmModalProps) {
+  return (
+    <ModalLayout desktopWidth={430} mobileWidth={320} modalType="confirm">
+      <Container>
+        <Message>{CONFIRM_TYPE[type].massage}</Message>
+        <Wrapper>
+          <Button variant="primaryLight">{CONFIRM_TYPE[type].cancel}</Button>
+          <Button variant="primary">{CONFIRM_TYPE[type].agree}</Button>
+        </Wrapper>
+      </Container>
+    </ModalLayout>
+  );
+}
+
+const { color, mediaQueries } = DESIGN_TOKEN;
+
+const Container = styled.div`
+  width: 35rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4rem;
+  padding-top: 6rem;
+  padding-bottom: 4rem;
+
+  ${mediaQueries.mobile} {
+    width: 26rem;
+    padding-top: 5rem;
+    padding-bottom: 3rem;
+  }
+`;
+
+const Message = styled.div`
+  color: ${color.black[1]};
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 150%;
+`;
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 16.9rem);
+  gap: 1.2rem;
+
+  ${mediaQueries.mobile} {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 0.8rem;
+    width: 100%;
+  }
+`;

--- a/co-kkiri/src/constants/modal.ts
+++ b/co-kkiri/src/constants/modal.ts
@@ -1,0 +1,11 @@
+export const CONFIRM_TYPE = {
+  apply: { massage: "정말 지원하시겠어요?", agree: "지원하기", cancel: "취소하기" },
+  post: { massage: "작성을 완료했습니까?", agree: "작성하기", cancel: "취소하기" }, //apply 외 나머지 메세지 정해지면 수정 예정
+  modify: { massage: "수정 하시겠어요?", agree: "수정하기", cancel: "취소하기" },
+  delete: { massage: "정말 삭제하시겠어요?", agree: "삭제하기", cancel: "취소하기" },
+  cancel: { massage: "정말 취소하시겠어요?", agree: "네", cancel: "아니오" },
+  review: { massage: "리뷰를 완료하셨나요?", agree: "네", cancel: "아니오" },
+  start: { massage: "스터디/프로젝트를 시작하시겠어요?", agree: "네", cancel: "아니오" },
+  accept: { massage: "수락하시겠어요?", agree: "수락하기", cancel: "취소하기" },
+  refuse: { massage: "거절하시겠어요?", agree: "거절하기", cancel: "취소하기" },
+};


### PR DESCRIPTION
### 📌요구사항
- [x] ConfirmModal 컴포넌트 UI 구현
- [x] constants 폴더 modal.ts 에 confirm type 분리

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
여러가지 타입의 confirm 모달 내부 텍스트가 아직 미정이라 임의로 넣은 상태입니다. 
정해지면 수정해서 반영해놓겠습니다.   

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148737398/0ff8a08d-dd45-4fea-b337-feb6aa25215b



### 📌이슈 번호
close #25
