### PR TITLE
Feat: default chip 확장 및 추가 chip 구현

### DIFF
--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -47,24 +47,13 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
   padding: 0.4rem 1.2rem;
 
   display: flex;
+  position: relative;
 
   background-color: ${color.gray[3]};
   color: ${color.black[3]};
   border-radius: 9999rem;
 
   ${typography.font12Semibold}
-
-  ${({ $isVertical }) => $isVertical ? `
-      flex-direction: column;
-      align-items: center;
-      gap: .4rem;
-      padding: .8rem;
-    ` : `
-      flex-direction: row;
-      align-items: center;
-      gap: 1.2rem;
-      `
-  }
 
   ${({$isClickable}) => $isClickable && `cursor: pointer;`}
 
@@ -81,6 +70,25 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
     width: 1.4rem;
     height: 1.4rem;
     ${({$isClickable}) => $isClickable && `cursor: pointer;`}
+  }
+
+  ${({ $isVertical }) => $isVertical ? `
+      flex-direction: column;
+      border-radius: 1rem;
+      align-items: center;
+      gap: .4rem;
+      padding: .8rem;
+
+      & .icon{
+        position: absolute;
+        top: .4rem;
+        right: .4rem;
+      }
+    ` : `
+      flex-direction: row;
+      align-items: center;
+      gap: 1.2rem;
+      `
   }
 
   -webkit-user-select: none;

--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -2,18 +2,29 @@ import { MouseEvent } from "react";
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 
+interface Icon {
+  src: string;
+  alt: string;
+}
+
 interface DefaultChipProps {
   label: string;
+  imgUrl?: string;
+  icon?: Icon;
+
   isSelected?: boolean;
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  onIconClick?: (e: MouseEvent<HTMLImageElement>) => void;
   isVertical?: boolean;
   className?: string;
 }
 
-export default function DefaultChip({ label, isSelected, onClick, isVertical, className }: DefaultChipProps) {
+export default function DefaultChip({ label, imgUrl, icon, isSelected, onClick, onIconClick, isVertical, className }: DefaultChipProps) {
   return (
-    <Container className={className} $isVertical={isVertical} $isSelected={isSelected} onClick={onClick}>
-      {label}
+    <Container className={className} $isVertical={isVertical} $isSelected={isSelected} $isClickable={(onClick || onIconClick) ? true : false} onClick={!icon ? onClick : undefined}>
+      {imgUrl && <div className="image-container"><img className="image" src={imgUrl} alt={label} /></div>}
+      <span className="label">{label}</span>
+      {icon && <img className="icon" src={icon.src} alt={icon.alt} onClick={onIconClick} />}
     </Container>
   );
 }
@@ -21,10 +32,12 @@ export default function DefaultChip({ label, isSelected, onClick, isVertical, cl
 /**
  * @param $isVertical: boolean - 세로로 배치할지 여부
  * @param $isSelected: boolean - 선택되었는지 여부
+ * @param $isClickable: boolean - 클릭 가능한지 여부
  */
 export interface DefaultChipContainerStyleProps {
   $isVertical?: boolean;
   $isSelected?: boolean;
+  $isClickable?: boolean
 }
 
 const { color, typography } = DESIGN_TOKEN;
@@ -44,11 +57,29 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
   ${({ $isVertical }) => $isVertical ? `
       flex-direction: column;
       align-items: center;
-      gap: .4rem
+      gap: .4rem;
+      padding: .8rem;
     ` : `
       flex-direction: row;
       align-items: center;
-      gap: 1.2rem
+      gap: 1.2rem;
       `
-  })
+  }
+
+  ${({$isClickable}) => $isClickable && `cursor: pointer;`}
+
+  & .image-container{
+    width: 3.6rem;
+    height: 3.6rem;
+  }
+
+  & .image{
+    object-fit: cover;
+  }
+
+  & .icon{
+    width: 1.4rem;
+    height: 1.4rem;
+    ${({$isClickable}) => $isClickable && `cursor: pointer;`}
+  }
 `;

--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -8,18 +8,20 @@ interface DefaultChipProps {
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
   style?: DefaultChipContainerStyleProps;
   selectedStyle?: DefaultChipContainerStyleProps;
+  isVertical: boolean;
 }
 
-export default function DefaultChip({ label, isSelected, onClick, style, selectedStyle }: DefaultChipProps) {
+export default function DefaultChip({ label, isSelected, onClick, style, selectedStyle, isVertical }: DefaultChipProps) {
   const currentStyle = isSelected ? selectedStyle : style;
   return (
-    <Container {...currentStyle} onClick={onClick}>
+    <Container $isVertical={isVertical} {...currentStyle} onClick={onClick}>
       {label}
     </Container>
   );
 }
 
 export interface DefaultChipContainerStyleProps {
+  $isVertical?: boolean;
   $padding?: CSSProperties["padding"];
   $backgroundColor?: CSSProperties["backgroundColor"];
   $fontColor?: CSSProperties["color"];
@@ -32,9 +34,22 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
   width: fit-content;
   padding: ${({ $padding }) => $padding || `0.4rem 1.2rem`};
 
+  display: flex;
+
   background-color: ${({ $backgroundColor }) => $backgroundColor || color.gray[3]};
   color: ${({ $fontColor }) => $fontColor || color.black[3]};
   border-radius: ${({ $borderRadius }) => $borderRadius || `9999rem`};
 
   ${typography.font12Semibold}
+
+  ${({ $isVertical }) => $isVertical ? `
+      flex-direction: column;
+      align-items: center;
+      gap: .4rem
+    ` : `
+      flex-direction: row;
+      align-items: center;
+      gap: 1.2rem
+      `
+  })
 `;

--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -82,4 +82,9 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
     height: 1.4rem;
     ${({$isClickable}) => $isClickable && `cursor: pointer;`}
   }
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 `;

--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -1,44 +1,43 @@
 import { MouseEvent } from "react";
 import DESIGN_TOKEN from "@/styles/tokens";
-import styled, { CSSProperties } from "styled-components";
+import styled from "styled-components";
 
 interface DefaultChipProps {
   label: string;
   isSelected?: boolean;
   onClick?: (e: MouseEvent<HTMLDivElement>) => void;
-  style?: DefaultChipContainerStyleProps;
-  selectedStyle?: DefaultChipContainerStyleProps;
-  isVertical: boolean;
+  isVertical?: boolean;
+  className?: string;
 }
 
-export default function DefaultChip({ label, isSelected, onClick, style, selectedStyle, isVertical }: DefaultChipProps) {
-  const currentStyle = isSelected ? selectedStyle : style;
+export default function DefaultChip({ label, isSelected, onClick, isVertical, className }: DefaultChipProps) {
   return (
-    <Container $isVertical={isVertical} {...currentStyle} onClick={onClick}>
+    <Container className={className} $isVertical={isVertical} $isSelected={isSelected} onClick={onClick}>
       {label}
     </Container>
   );
 }
 
+/**
+ * @param $isVertical: boolean - 세로로 배치할지 여부
+ * @param $isSelected: boolean - 선택되었는지 여부
+ */
 export interface DefaultChipContainerStyleProps {
   $isVertical?: boolean;
-  $padding?: CSSProperties["padding"];
-  $backgroundColor?: CSSProperties["backgroundColor"];
-  $fontColor?: CSSProperties["color"];
-  $borderRadius?: CSSProperties["borderRadius"];
+  $isSelected?: boolean;
 }
 
 const { color, typography } = DESIGN_TOKEN;
 
 const Container = styled.div<DefaultChipContainerStyleProps>`
   width: fit-content;
-  padding: ${({ $padding }) => $padding || `0.4rem 1.2rem`};
+  padding: 0.4rem 1.2rem;
 
   display: flex;
 
-  background-color: ${({ $backgroundColor }) => $backgroundColor || color.gray[3]};
-  color: ${({ $fontColor }) => $fontColor || color.black[3]};
-  border-radius: ${({ $borderRadius }) => $borderRadius || `9999rem`};
+  background-color: ${color.gray[3]};
+  color: ${color.black[3]};
+  border-radius: 9999rem;
 
   ${typography.font12Semibold}
 

--- a/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import DefaultChip from "./DefaultChip";
+import { MouseEvent } from "react";
+import { ICONS } from "@/constants/icons";
+
+interface DeleteStackChipProps {
+    label: string;
+    onClick: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function DeleteStackChip({ label, onClick }: DeleteStackChipProps
+) {
+    return <Container label={label} icon={ICONS.deleted} onClick={onClick} />;
+}
+
+const Container = styled(DefaultChip)`
+    padding: 0.4rem .8rem .4rem 1.2rem;
+`

--- a/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
@@ -1,27 +1,40 @@
-import DefaultChip, { DefaultChipContainerStyleProps } from "./DefaultChip";
+import styled, { css } from "styled-components";
+import DefaultChip from "./DefaultChip";
+import { VariantStyle } from "@/types/styledUtilTypes";
+
+export type ProjectType = "스터디" | "프로젝트";
 
 interface ProjectChipProps {
-  label: "스터디" | "프로젝트"; //나중에 global한 type으로 빼내어야함
+  label: ProjectType; //나중에 global한 type으로 빼내어야함
 }
-
-const ProjectChipStyle: DefaultChipContainerStyleProps = {
-  $padding: `.6rem 3rem`,
-  $borderRadius: `.2rem 6.1rem 6.1rem .2rem`,
-};
-
-const studyProjectChipStyle: DefaultChipContainerStyleProps = {
-  $backgroundColor: `#DAF4AF`,
-  $fontColor: `#588F00`,
-  ...ProjectChipStyle,
-};
-
-const projectProjectChipStyle: DefaultChipContainerStyleProps = {
-  $backgroundColor: `#FFDBE4`,
-  $fontColor: `#C71B44`,
-  ...ProjectChipStyle,
-};
 
 export default function ProjectChip({ label }: ProjectChipProps) {
-  const projectChipStyle = label === "스터디" ? studyProjectChipStyle : projectProjectChipStyle;
-  return <DefaultChip label={label} style={projectChipStyle} />;
+  return <Container label={label}/>;
 }
+
+
+type ProjectVariant = ProjectType;
+
+const ProjectChipStyle = css`
+  padding: .6rem 3rem;
+  border-radius: .2rem 6.1rem 6.1rem .2rem;
+  `
+  ;
+
+const VARIANT_STYLE: VariantStyle<ProjectVariant> = {
+  '스터디': css`
+    background-color: #DAF4AF;
+    color: #588F00;
+    ${ProjectChipStyle}
+    `
+  ,
+  '프로젝트': css`
+    background-color: #FFDBE4;
+    color:#C71B44;
+    ${ProjectChipStyle}
+  `
+}
+
+const Container = styled(DefaultChip)`
+  ${({ label }) => VARIANT_STYLE[label as ProjectVariant]}
+`

--- a/co-kkiri/src/components/commons/Chips/SelectPositionChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/SelectPositionChip.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+import DefaultChip from "./DefaultChip";
+import { MouseEvent } from "react";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+interface SelectPositionChipProps{
+    label: string;
+    isSelected?: boolean;
+    onClick: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function SelectPositionChip({ label, isSelected, onClick }: SelectPositionChipProps
+) {
+    return <Container label={label} isSelected={isSelected} onClick={onClick} isVertical />;
+}
+
+const {color, typography} = DESIGN_TOKEN;
+const Container = styled(DefaultChip)`
+    padding: .7rem 2rem;
+
+    background-color: ${color.white};
+    color: ${color.black[1]};
+    border: .1rem solid ${color.gray[2]};
+
+    ${typography.font14Medium}
+
+    ${({ isSelected }) => isSelected && `
+    color: ${color.secondary};
+    border: .1rem solid ${color.secondary};
+    `}
+`;

--- a/co-kkiri/src/components/commons/Chips/SelectPositionChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/SelectPositionChip.tsx
@@ -11,7 +11,7 @@ interface SelectPositionChipProps{
 
 export default function SelectPositionChip({ label, isSelected, onClick }: SelectPositionChipProps
 ) {
-    return <Container label={label} isSelected={isSelected} onClick={onClick} isVertical />;
+    return <Container label={label} isSelected={isSelected} onClick={onClick} />;
 }
 
 const {color, typography} = DESIGN_TOKEN;

--- a/co-kkiri/src/components/commons/Chips/StackChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/StackChip.tsx
@@ -1,0 +1,57 @@
+import { MouseEvent } from "react";
+import styled from "styled-components";
+import DefaultChip from "./DefaultChip";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+interface StackChipProps {
+    label: string;
+    imgUrl: string;
+    isSelected?: boolean;
+    onClick: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function StackChip({ label, imgUrl, isSelected, onClick }: StackChipProps
+) {
+    return <Container label={label} imgUrl={imgUrl} isSelected={isSelected} onClick={onClick} isVertical />;
+}
+
+const { color, typography, mediaQueries } = DESIGN_TOKEN;
+const Container = styled(DefaultChip)`
+    width: 7rem;
+    height: 7.2rem;
+
+    padding: .8rem;
+    gap: .4rem;
+
+    background-color: ${color.white};
+    border: .1rem solid ${color.gray[2]};
+    border-radius: 1rem;
+    color: ${color.black[1]};
+
+    ${({ isSelected }) => !isSelected && `opacity: .4;`}
+
+    ${typography.font12normal}
+
+
+    
+    ${mediaQueries.mobile}{
+        width: fit-content;
+        height: fit-content;
+
+        padding: .3rem 1.2rem;
+
+        border-radius: 9999rem;
+
+        & .image-container{
+            display: none;
+        }
+
+        ${({ isSelected }) => isSelected && `
+            background-color: ${color.white};
+            color: ${color.secondary};
+
+            border-color: ${color.secondary};
+        `}
+    }
+    
+`

--- a/co-kkiri/src/styles/tokens.ts
+++ b/co-kkiri/src/styles/tokens.ts
@@ -26,6 +26,7 @@ const DESIGN_TOKEN = {
     secondary: "#FF9B52",
   },
   typography: {
+    font12normal: "font-size: 1.2rem; line-height: normal; font-weight: 400;",
     font12Semibold: "font-size: 1.2rem; line-height: normal; font-weight: 600;",
     font14Regular: "font-size: 1.4rem; line-height: 150%; font-weight: 400;",
     font14Medium: "font-size: 1.4rem; line-height: 150%; font-weight: 500;",


### PR DESCRIPTION
### 📌요구사항
- [x] DefaultChip 기능 확장
- [x] 모든 Chip의 기본 베이스인 DefaultChip를 이미지를 받고, 배치할 수 있도록 함
- [x] 선택가능 칩
- [x] 취소가능 칩
- [x] 이미지 + 정보 칩

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
# DefaultChip 컴포넌트 사용 가이드

`DefaultChip`은 다양한 상황에서 사용 가능한 범용 UI 컴포넌트입니다. 본 가이드는 개발자가 `DefaultChip`을 효과적으로 활용할 수 있도록 돕습니다.

## 컴포넌트 구조

`DefaultChip`은 다음 props를 지원합니다

- **`label`** (필수): 칩의 주요 텍스트 내용입니다.
- `imgUrl` (옵셔널): 칩에 표시할 이미지 URL입니다.  
- `icon` (옵셔널): 칩에 포함할 아이콘 정보로, `src`와 `alt` 텍스트를 가진 객체 형태입니다.
- `isSelected` (옵셔널): 칩의 선택 상태를 나타내며, 시각적으로 구분됩니다.
- `onClick` (옵셔널): 칩 클릭 시 실행될 콜백 함수입니다.
- `onIconClick` (옵셔널): 아이콘 클릭 시 실행될 콜백 함수로, 아이콘이 존재할 때만 유효합니다.
- `isVertical` (옵셔널): 칩 내용의 수직 배치 여부를 결정합니다. 
- `className` (옵셔널): 요건 쓰실일이 없을겁니다. 추가 컴포넌트 만들 때 `styled(DefaultChip)`를 쓰기 위해서 넣은거에요. styled-component가 자동으로 사용하는 친구입니다.

## 사용 예시

```jsx
<DefaultChip
  label="반갑습니다"
  imgUrl="https://example.com/image.svg"
  icon={{ src: "https://example.com/icon.svg", alt: "아이콘 설명" }}
  onClick={() => { console.log("Chip 클릭됨"); }}
  isVertical={true}
/>
```

## 스타일링

`DefaultChip`를 덮어 다른 Chip을 만들기 위해서는 아래와같은 코드를 사용하시면 됩니다
```tsx
export default function SelectPositionChip({ label, isSelected, onClick }: SelectPositionChipProps
) {
    return <Container label={label} isSelected={isSelected} onClick={onClick} />;
}

const Container = styled(DefaultChip)`
...
`;
```

## 접근성 고려사항

`user-select: none;` 속성이 적용되어 텍스트 선택이 불가능합니다. 사용자가 실수로 칩 텍스트를 드래그하여 선택하는 것을 방지하기 위함인데, 접근성에 이슈가 있을까 고민이 됩니다

## 사용 시 유의사항

- 아이콘 클릭과 칩 클릭은 별도로 처리됩니다. 아이콘이 있을 경우, 칩 본문 클릭 시 `onClick`은 실행되지 않고 아이콘 클릭 시에만 `onIconClick`이 실행됩니다.
- `isVertical` 옵션을 통해 내용 배치를 쉽게 조정할 수 있어, 다양한 레이아웃 요구사항에 대응 가능합니다. 다만 이 때, 아이콘이 우측 상단에 자동 배치됩니다 :)
- `isSelected`를 통해 선택 상태를 시각적으로 구분할 수 있어, 사용자의 상태 인지가 용이해집니다.

### 📌스크린샷 / 테스트결과 (선택)
https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/023771cf-4e2a-4e97-8f0a-fdb052c90bb4


### 📌이슈 번호
Closes: #39 