### PR TITLE
Feat: FilterDropdownButton 구현

### DIFF
--- a/co-kkiri/src/components/commons/DropdownButton.tsx
+++ b/co-kkiri/src/components/commons/DropdownButton.tsx
@@ -19,6 +19,7 @@ export default function DropdownButton({ selectOption, toggleDropdown }: Dropdow
 const { typography, color } = DESIGN_TOKEN;
 
 const Container = styled.div`
+  height: 3.6rem;
   display: flex;
   align-items: center;
   gap: 0.4rem;

--- a/co-kkiri/src/components/commons/DropdownMenu.tsx
+++ b/co-kkiri/src/components/commons/DropdownMenu.tsx
@@ -3,12 +3,11 @@ import DESIGN_TOKEN from "@/styles/tokens";
 
 interface DropdownMenuProps {
   selectType: "position" | "meeting" | "sortList";
-  setSelectOption: (option: string) => void;
+  handleSelectOption: (option: string) => void;
   isOpen: boolean;
-  toggleDropdown: () => void;
 }
 
-export default function DropdownMenu({ selectType, setSelectOption, isOpen, toggleDropdown }: DropdownMenuProps) {
+export default function DropdownMenu({ selectType, isOpen, handleSelectOption }: DropdownMenuProps) {
   const optionList = {
     position: ["전체", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
     meeting: ["전체", "온라인", "오프라인", "온/오프라인"],
@@ -16,12 +15,11 @@ export default function DropdownMenu({ selectType, setSelectOption, isOpen, togg
   };
 
   return (
-    <Container isOpen={isOpen}>
+    <Container $isOpen={isOpen}>
       {optionList[selectType].map((option: string) => (
         <Option
           onClick={() => {
-            setSelectOption(option);
-            toggleDropdown();
+            handleSelectOption(option);
           }}
           key={option}>
           {option}
@@ -31,17 +29,19 @@ export default function DropdownMenu({ selectType, setSelectOption, isOpen, togg
   );
 }
 
-const { typography, color } = DESIGN_TOKEN;
+const { typography, color, zIndex } = DESIGN_TOKEN;
 
-const Container = styled.div<{ isOpen: boolean }>`
-  display: ${(props) => (props.isOpen ? "flex" : "none")};
+const Container = styled.div<{ $isOpen: boolean }>`
+  display: ${(props) => (props.$isOpen ? "flex" : "none")};
   flex-direction: column;
   width: 10.4rem;
-  padding: 1.6rem 0;
-  padding-left: 1.4rem;
+  padding: 1.6rem 1.4rem;
   border-radius: 2rem;
   border: 0.1rem solid ${color.gray[2]};
   gap: 1.6rem;
+  position: absolute;
+  top: 4.2rem;
+  ${zIndex.popover}
 `;
 
 const Option = styled.div`

--- a/co-kkiri/src/components/commons/PopoverButton.tsx
+++ b/co-kkiri/src/components/commons/PopoverButton.tsx
@@ -4,17 +4,17 @@ import DESIGN_TOKEN from "@/styles/tokens";
 import { ICONS } from "@/constants/icons";
 
 interface PopoverButtonProps {
-  children: ReactNode;
+  selectOption: string;
   isSelected: boolean;
   onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const { popover, popoverSelected } = ICONS;
 
-export default function PopoverButton({ children, isSelected, onClick }: PopoverButtonProps) {
+export default function PopoverButton({ selectOption, onClick, isSelected }: PopoverButtonProps) {
   return (
     <Container $isSelected={isSelected} onClick={onClick}>
-      {children}
+      {selectOption}
       {isSelected ? (
         <Arrow src={popoverSelected.src} alt={popoverSelected.alt} />
       ) : (

--- a/co-kkiri/src/components/commons/SelectDropOptions/FilterDropdownButton.tsx
+++ b/co-kkiri/src/components/commons/SelectDropOptions/FilterDropdownButton.tsx
@@ -32,12 +32,10 @@ export default function FilterDropdownButton({ filterType }: FilterDropdownButto
   };
 
   return (
-    <div ref={ref}>
-      <Container>
-        <PopoverButton onClick={toggleDropdown} selectOption={selectOption} isSelected={isSelected} />
-        <DropdownMenu isOpen={isOpen} handleSelectOption={handleSelectOption} selectType={filterType} />
-      </Container>
-    </div>
+    <Container ref={ref}>
+      <PopoverButton onClick={toggleDropdown} selectOption={selectOption} isSelected={isSelected} />
+      <DropdownMenu isOpen={isOpen} handleSelectOption={handleSelectOption} selectType={filterType} />
+    </Container>
   );
 }
 

--- a/co-kkiri/src/components/commons/SelectDropOptions/FilterDropdownButton.tsx
+++ b/co-kkiri/src/components/commons/SelectDropOptions/FilterDropdownButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import styled from "styled-components";
+import DropdownMenu from "../DropdownMenu";
+import PopoverButton from "../PopoverButton";
+import useOpenToggle from "@/hooks/useOpenToggle";
+
+interface FilterDropdownButtonProps {
+  filterType: "position" | "meeting";
+}
+
+const filterDefaultValue = {
+  position: "포지션",
+  meeting: "진행 방식",
+};
+
+/**
+ * FilterDropdownButton 컴포넌트
+ * filterType에 따라 dropdown 옵션이 정해집니다.
+ * @property {"position"|"meeting"} filterType
+ * */
+export default function FilterDropdownButton({ filterType }: FilterDropdownButtonProps) {
+  const defaultValue = filterDefaultValue[filterType];
+
+  const [selectOption, setSelectOption] = useState(defaultValue);
+  const [isSelected, setIsSelected] = useState(false);
+  const { isOpen, openToggle: toggleDropdown, ref } = useOpenToggle();
+
+  const handleSelectOption = (option: string) => {
+    setSelectOption(option);
+    setIsSelected(true);
+    toggleDropdown();
+  };
+
+  return (
+    <div ref={ref}>
+      <Container>
+        <PopoverButton onClick={toggleDropdown} selectOption={selectOption} isSelected={isSelected} />
+        <DropdownMenu isOpen={isOpen} handleSelectOption={handleSelectOption} selectType={filterType} />
+      </Container>
+    </div>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  gap: 0.6rem;
+  position: relative;
+`;

--- a/co-kkiri/src/components/commons/SelectDropOptions/SortSelectButton.tsx
+++ b/co-kkiri/src/components/commons/SelectDropOptions/SortSelectButton.tsx
@@ -2,31 +2,29 @@ import styled from "styled-components";
 import DropdownMenu from "../DropdownMenu";
 import DropdownButton from "../DropdownButton";
 import { useState } from "react";
+import useOpenToggle from "@/hooks/useOpenToggle";
 
 export default function SortSelectButton() {
   const [selectOption, setSelectOption] = useState("최신순");
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, openToggle: toggleDropdown, ref } = useOpenToggle();
 
-  const toggleDropdown = () => {
-    setIsOpen(!isOpen);
+  const handleSelectOption = (option: string) => {
+    setSelectOption(option);
+    toggleDropdown();
   };
 
   return (
-    <Container>
+    <Container ref={ref}>
       <DropdownButton toggleDropdown={toggleDropdown} selectOption={selectOption} />
-      <DropdownMenu
-        isOpen={isOpen}
-        toggleDropdown={toggleDropdown}
-        setSelectOption={setSelectOption}
-        selectType="sortList"></DropdownMenu>
+      <DropdownMenu isOpen={isOpen} handleSelectOption={handleSelectOption} selectType="sortList"></DropdownMenu>
     </Container>
   );
 }
 
 const Container = styled.div`
-  width: 10.4rem;
   display: flex;
   flex-direction: column;
   align-items: end;
   gap: 1.6rem;
+  position: relative;
 `;

--- a/co-kkiri/src/components/modals/ConfirmModal.tsx
+++ b/co-kkiri/src/components/modals/ConfirmModal.tsx
@@ -4,7 +4,7 @@ import Button from "../commons/Button";
 import DESIGN_TOKEN from "@/styles/tokens";
 import { CONFIRM_TYPE } from "@/constants/modal";
 
-type ConfirmType = "apply" | "post" | "modify" | "delete" | "cancel" | "review" | "start" | "accept" | "refuse";
+type ConfirmType = keyof typeof CONFIRM_TYPE;
 
 interface ConfirmModalProps {
   type: ConfirmType;

--- a/co-kkiri/src/hooks/useOpenToggle.ts
+++ b/co-kkiri/src/hooks/useOpenToggle.ts
@@ -1,0 +1,32 @@
+import { useRef } from "react";
+import { useOnClickOutside, useToggle } from "usehooks-ts";
+import { Dispatch, SetStateAction, MutableRefObject } from "react";
+
+interface UseOpenToggleReturn {
+  isOpen: boolean;
+  openToggle: () => void;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  ref: MutableRefObject<HTMLDivElement | null>;
+}
+
+/**
+ * useOpenToggle 훅을 사용하여 모달 혹은 옵션 메뉴의 열림/닫힘 상태를 관리합니다.
+ *
+ * 이 훅은 isOpen 상태, 상태를 토글하는 openToggle 함수, 상태를 직접 설정하는 setIsOpen 함수,
+ * 그리고 외부 클릭을 감지하는데 사용되는 ref를 반환합니다. 외부 클릭 시 옵션 메뉴가 닫히도록 설정합니다.
+ *
+ * @returns {UseOpenToggleReturn} isOpen: 옵션 메뉴가 열려있는지 여부를 나타내는 boolean 값,
+ *                                openToggle: 옵션 메뉴의 열림 상태를 토글하는 함수,
+ *                                setIsOpen: 옵션 메뉴의 열림 상태를 직접 설정하는 setter함수,
+ *                                ref: 컴포넌트 외부의 클릭을 감지하기 위한 ref 객체.
+ */
+export default function useOpenToggle(): UseOpenToggleReturn {
+  const [isOpen, openToggle, setIsOpen] = useToggle();
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  const close = () => isOpen && setIsOpen(false);
+
+  useOnClickOutside(ref, close);
+
+  return { isOpen, openToggle, setIsOpen, ref };
+}


### PR DESCRIPTION
### 📌요구사항
- [x] FilterDropdownButton 구현
- [x] useOpenToggle 구현 

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

- 훅 적용해서 SortSelectButton도 수정했습니다.
- DropdownMenu, DropdownButton 스타일 코드 조금 수정했습니다.

#### useOpenToggle hook 설명 
useOpenToggle hook은 컴포넌트에서 모달, 팝오버, 드롭다운 등의 열림/닫힘 상태를 관리하기 위한 커스텀 훅입니다. 
usehooks-ts의 useToggle 과 useOnClickOuside를 결합하여 간단하게 만들었습니다. 
이 훅은 옵션 메뉴가 열려 있는지 여부(isOpen), 옵션 메뉴의 열림 상태를 토글하는 함수(openToggle), 옵션 메뉴의 열림 상태를 직접 설정할 수 있는 setter함수(setIsOpen), 그리고 컴포넌트 외부 클릭을 감지하여 옵션 메뉴를 자동으로 닫는 기능을 위한 참조(ref)를 제공합니다.

* 사용 예시
```
import useOpenToggle from '@/hooks/useOpenToggle';

const Dropdown = () => {
  const { isOpen, openToggle, setIsOpen, ref } = useOpenToggle();

  return (
    <div ref={ref}> 
      <button onClick={openToggle}>Toggle Options</button>
      {isOpen && (
        <div>
          <p>Option 1</p>
          <p>Option 2</p>
          <p>Option 3</p>
          <button onClick={() => setIsOpen(false)}>Close Menu</button> 
        </div>
      )}
    </div>
  );
};

export default Dropdown;

```

commons폴더 아래 SelectDropOptions 폴더에 있는 컴포넌트들이 사용중이니 실제 코드에서 확인해보시구
해당 훅에 JSDoc도 작성했으니 사용하실 때 참고해보세요!

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148737398/bcb31951-4816-42c7-ba1d-46f95d8d5cef



### 📌이슈 번호
close #43 