### PR TITLE
Feat: 상세 페이지 요약 카드 구현

### DIFF
--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
@@ -12,6 +12,7 @@ export interface ProjectDetailRowProps {
 
 export default function ProjectDetailRow({ label, content, renderType }: ProjectDetailRowProps) {
 
+    //Chip이랑 Icon은 배열이어야만 정상적으로 render함
     const renderContent = useCallback(() => {
         switch (renderType) {
             case "text":

--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
@@ -1,5 +1,4 @@
 import PositionChip from "@/components/commons/Chips/PositionChip";
-import StackChip from "@/components/commons/Chips/StackChip";
 import DESIGN_TOKEN from "@/styles/tokens";
 import { useCallback } from "react";
 import styled from "styled-components";

--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
@@ -1,0 +1,74 @@
+import PositionChip from "@/components/commons/Chips/PositionChip";
+import StackChip from "@/components/commons/Chips/StackChip";
+import DESIGN_TOKEN from "@/styles/tokens";
+import { useCallback } from "react";
+import styled from "styled-components";
+
+export interface ProjectDetailRowProps {
+    label: string;
+    content: string | string[];
+    renderType: string;
+}
+
+export default function ProjectDetailRow({ label, content, renderType }: ProjectDetailRowProps) {
+
+    const renderContent = useCallback(() => {
+        switch (renderType) {
+            case "text":
+                return <p>{content}</p>;
+                break;
+            case "positionChip":
+                if (Array.isArray(content)) {
+                    return <div className="chip position">{content.map((item) => <PositionChip key={item} label={item} />)}</div>
+                }
+                break;
+            case "stackIcon":
+                if (Array.isArray(content)) {
+                    //TODO: 임시, 추후 stackIcon으로 변경
+                    return <div className="chip stack">{content.map((item) => <div key={item}><img src={item}/></div>)}</div>
+                }
+        }
+    }, [content, renderType])
+
+    return (
+        <Container>
+            <div className="label"><span>{label}</span></div>
+            {renderContent()}
+        </Container>
+    )
+
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const Container = styled.div`
+    width: 100%;
+
+    display: flex;
+    align-items: flex-start;
+
+    ${typography.font16Semibold}
+
+    & > .label{
+        width: 10rem;
+        color: ${color.gray[1]};
+    }
+
+    & > .text{
+        color: ${color.black[1]};
+    }
+
+    & > .chip{
+        display: flex;
+        flex-wrap: wrap;
+        flex-shrink: 1;
+    }
+
+    & > .chip.position{
+        gap: .6rem;
+    }
+
+    & > .chip.stack{
+        gap: .8rem;
+    }
+`;

--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailRow.tsx
@@ -2,11 +2,12 @@ import PositionChip from "@/components/commons/Chips/PositionChip";
 import DESIGN_TOKEN from "@/styles/tokens";
 import { useCallback } from "react";
 import styled from "styled-components";
+import { RenderType } from "./types";
 
 export interface ProjectDetailRowProps {
     label: string;
     content: string | string[];
-    renderType: string;
+    renderType: RenderType;
 }
 
 export default function ProjectDetailRow({ label, content, renderType }: ProjectDetailRowProps) {

--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailTable.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailTable.tsx
@@ -1,3 +1,15 @@
-export default function ProjectDetailTable() {
-    return <div>ProjectDetailTable</div>;
+import styled from "styled-components";
+
+interface ProjectDetailTableProps {
+    children: React.ReactNode;
 }
+
+export default function ProjectDetailTable({children}: ProjectDetailTableProps) {
+    return <Container>{children}</Container>;
+}
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2.4rem;
+`

--- a/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailTable.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/ProjectDetailTable.tsx
@@ -1,0 +1,3 @@
+export default function ProjectDetailTable() {
+    return <div>ProjectDetailTable</div>;
+}

--- a/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
@@ -2,16 +2,60 @@ import ProjectChip, { ProjectType } from "@/components/commons/Chips/ProjectChip
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 import ProjectDetailTable from "./ProjectDetailTable";
+import { ProjectDetailConfig, ProjectDetailContentType } from "./types";
+import ProjectDetailRow from "./ProjectDetailRow";
 
-interface ProjectDetailCardProps {
+interface ProjectDetailCardProps extends ProjectDetailContentType {
     ProjectCategory: ProjectType;
 }
 
-export default function ProjectDetailCard({ProjectCategory}: ProjectDetailCardProps) {
+
+export default function ProjectDetailCard({ ProjectCategory, ...projectDetailContents }: ProjectDetailCardProps) {
+
+    const projectDetailConfig: ProjectDetailConfig = {
+        'recruitEndAt': {
+            "label": "모집 마감",
+            "content": projectDetailContents.recruitEndAt,
+            "renderType": "text",
+        },
+        'progressPeriod':{
+            "label": "진행 기간",
+            "content": projectDetailContents.progressPeriod,
+            "renderType": "text",
+        },
+        'progressWay':{
+            "label": "진행 방식",
+            "content": projectDetailContents.progressWay,
+            "renderType": "text",
+        },
+        'contactWay':{
+            "label": "연락 방법",
+            "content": projectDetailContents.contactWay,
+            "renderType": "text",
+        },
+        'capacity':{
+            "label": "모집 인원",
+            "content": projectDetailContents.capacity,
+            "renderType": "text",
+        },
+        'positions':{
+            "label": "모집 포지션",
+            "content": projectDetailContents.positions,
+            "renderType": "positionChip",
+        },
+        'stacks':{
+            "label": "기술 스택",
+            "content": projectDetailContents.stacks,
+            "renderType": "stackIcon",
+        }
+    }
 
     return <Container>
-        <Box><ProjectChip label={ProjectCategory}/></Box>
+        <Box><ProjectChip label={ProjectCategory} /></Box>
         <ProjectDetailTable>
+            {Object.values(projectDetailConfig).map((value) => {
+                return <ProjectDetailRow {...value} />
+            })}
         </ProjectDetailTable>
     </Container>;
 }

--- a/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
@@ -12,6 +12,7 @@ interface ProjectDetailCardProps extends ProjectDetailContentType {
 
 export default function ProjectDetailCard({ ProjectCategory, ...projectDetailContents }: ProjectDetailCardProps) {
 
+    // 이 친구가 여기 있으면 안될 것 같은데 추후에 코드를 수정해서 밖으로 빼던 해야할 듯 합니다
     const projectDetailConfig: ProjectDetailConfig = {
         'recruitEndAt': {
             "label": "모집 마감",

--- a/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
@@ -1,0 +1,51 @@
+import ProjectChip, { ProjectType } from "@/components/commons/Chips/ProjectChip";
+import DESIGN_TOKEN from "@/styles/tokens";
+import styled from "styled-components";
+import ProjectDetailTable from "./ProjectDetailTable";
+
+interface ProjectDetailCardProps {
+    ProjectCategory: ProjectType;
+}
+
+export default function ProjectDetailCard({ProjectCategory}: ProjectDetailCardProps) {
+
+    return <Container>
+        <Box><ProjectChip label={ProjectCategory}/></Box>
+        <ProjectDetailTable>
+        </ProjectDetailTable>
+    </Container>;
+}
+
+const { color, boxShadow, mediaQueries } = DESIGN_TOKEN;
+
+const Container = styled.div`
+    height: fit-content;
+
+    padding: 8rem 3rem 3rem;
+    position: relative;
+
+    background-color: ${color.white};
+
+    border-radius: 1.5rem;
+    box-shadow: ${boxShadow.content};
+
+    ${mediaQueries.mobile}{
+        width: 32rem;
+    }
+
+    ${mediaQueries.tablet}{
+        width: 50rem;
+    }
+
+    ${mediaQueries.desktop}{
+        width: 35rem;
+    }
+`
+
+const Box = styled.div`
+    position: absolute;
+    top: 3rem;
+    left: -0.2rem;
+    width: fit-content;
+    height: fit-content;
+`

--- a/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/index.tsx
@@ -29,7 +29,7 @@ export default function ProjectDetailCard({ ProjectCategory, ...projectDetailCon
             "renderType": "text",
         },
         'contactWay':{
-            "label": "연락 방법",
+            "label": "연락 방식",
             "content": projectDetailContents.contactWay,
             "renderType": "text",
         },

--- a/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
@@ -1,0 +1,21 @@
+import { GetTypeFromObject } from "@/types/ObjectUtilTypes";
+
+// ProjectDetailCard내 Table에서 사용되는 Key
+export type ProjectDetailKey = "recruitEndAt" | "progressPeriod" | "progressWay" | "contactWay" | "positions" | "stacks";
+
+// 구체적인 렌더링 방식
+export type RenderType = "text" | "positionChip" | "stackChip";
+
+// ProjectDetailCard 내부에서 Table에게 전달할 Table Config
+export type ProjectDetailConfig = {
+    [key in ProjectDetailKey]: {
+        label: string;
+        content: string | string[];
+        renderType: RenderType;
+    }
+}
+
+// ProjectDetailTable에서 사용할 content는 Card 외부에서 받을 예정, 따라서 타입에서 필요한 정보만 추출
+export type ProjectDetailContentType = {
+    [key in ProjectDetailKey]: GetTypeFromObject<ProjectDetailConfig[key], "content">;
+}

--- a/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
@@ -1,7 +1,7 @@
 import { GetTypeFromObject } from "@/types/ObjectUtilTypes";
 
 // ProjectDetailCard내 Table에서 사용되는 Key
-export type ProjectDetailKey = "recruitEndAt" | "progressPeriod" | "progressWay" | "contactWay" | "positions" | "stacks";
+export type ProjectDetailKey = "recruitEndAt" | "progressPeriod" | "progressWay" | "contactWay" | "capacity" |"positions" | "stacks";
 
 // 구체적인 렌더링 방식
 export type RenderType = "text" | "positionChip" | "stackChip";

--- a/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/domains/ProjectDetailCard/types.ts
@@ -4,7 +4,7 @@ import { GetTypeFromObject } from "@/types/ObjectUtilTypes";
 export type ProjectDetailKey = "recruitEndAt" | "progressPeriod" | "progressWay" | "contactWay" | "capacity" |"positions" | "stacks";
 
 // 구체적인 렌더링 방식
-export type RenderType = "text" | "positionChip" | "stackChip";
+export type RenderType = "text" | "positionChip" | "stackIcon";
 
 // ProjectDetailCard 내부에서 Table에게 전달할 Table Config
 export type ProjectDetailConfig = {

--- a/co-kkiri/src/types/ObjectUtilTypes.ts
+++ b/co-kkiri/src/types/ObjectUtilTypes.ts
@@ -1,0 +1,13 @@
+/** 객체에서 특정 Property의 Type을 추출하는 타입입니다 
+ * 
+ * @example
+    type A = {
+        label: string;
+        content: string | string[];
+        renderType: RenderType;
+    }
+
+    const a:GetTypeFromObject<A, "content"> = "hello"; // string | string[]
+ * 
+*/
+export type GetTypeFromObject<O, ObjectPropertyType extends PropertyKey> = O extends { [key in ObjectPropertyType]: infer ValueType } ? ValueType : never;


### PR DESCRIPTION
### 📌요구사항
- [x]  상세 페이지 요약 카드 컴포넌트 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
## ProjectDetailCard
- 프로젝트의 상세 정보를 집약적으로 보여주는 컴포넌트
- Table컴포넌트 내의 Row에 데이터를 map하여 보여줌
### Prop
- **ProjectCategory**
    - 스터디 / 프로젝트
- **ProjectDetailContentType**
```ProjectDetailKey를 기준으로 만들어진 Type```
    - **recruitEndAt**: 모집 마감일
    - **progressPeriod**: 프로젝트의 진행 기간
    - **progressWay**: 프로젝트의 진행 방식 (온라인, 오프라인 등)
    - **contactWay**: 연락 방법 (예: 이메일, 오픈톡 등)
    - **capacity**: 모집 인원
    - **positions**: 모집 포지션 (배열 형태로 여러 포지션 지정 가능)
    - **stacks**: 사용 기술 스택 (배열 형태로 여러 기술 지정 가능)
### 데이터 예시
```tsx
const projectDetailContents: ProjectDetailContentType = {
  'recruitEndAt': '2024.3.8',
  'progressPeriod': '2개월',
  'progressWay': '온/오프라인',
  'contactWay': '오픈톡',
  'capacity': '2명',
  'positions': ['프론트엔드','백엔드','기획','안드로이드'],
  'stacks': ['React','Node.js','MongoDB','Express','Java','Kotlin']
}
```
<br/><br/>
## ProjectDetailTable
- 테이블 디자인만 존재함
- 내부의 ProjectDetailRow를 넣으면 정해진 gap으로 배치됨
<br/><br/>
## ProjectDetailRow
- RenderType에 따라 데이터를 Render해서 Row를 만드는 컴포넌트

### Prop
- **label**: 제목
- **content**:내용, string 혹은 string 배열
- **renderType**: 렌더될 타입 - types.ts에 정의된 RenderType을 따릅니다
```tsx
export type RenderType = "text" | "positionChip" | "stackIcon";
//Chip이랑 Icon은 배열이어야만 정상적으로 render함
```

<br/><br/>
## types
### ProjectDetailConfig
- ProjectDetailCard 내부에서 Table에게 전달할 Table Config
- label에 붙을 이름과, 내부 내용, 렌더타입을 지정해주면됨
- 현재는 ProjectDetailCard 내에 직접적으로 객체를 만들었는데, 나중에 **수정**해야할 것 같습니다
```tsx
export type ProjectDetailConfig = {
    [key in ProjectDetailKey]: {
        label: string;
        content: string | string[];
        renderType: RenderType;
    }
}
```

<br/><br/>

### 📌스크린샷 / 테스트결과 (선택)
https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/330ce9bc-f1e7-4536-8341-1ffdd5e3eccb

### 📌이슈 번호
Closes: #21 
