### PR TITLE
Feat: radio button 컴포넌트 구현

### DIFF
--- a/co-kkiri/src/components/commons/RadioButton.tsx
+++ b/co-kkiri/src/components/commons/RadioButton.tsx
@@ -33,6 +33,7 @@ const RadioInput = styled.input`
   border-radius: 4.3rem;
   border: 0.1rem solid ${color.gray[2]};
   outline: none;
+  cursor: pointer;
 
   &:checked {
     background-color: ${color.secondary};

--- a/co-kkiri/src/components/commons/RadioButton.tsx
+++ b/co-kkiri/src/components/commons/RadioButton.tsx
@@ -1,0 +1,66 @@
+import DESIGN_TOKEN from "@/styles/tokens";
+import { ReactNode } from "react";
+import styled from "styled-components";
+
+interface RadioButtonProps {
+  children: ReactNode;
+  value: string;
+  defaultChecked?: boolean;
+}
+
+export default function RadioButton({ children, value, defaultChecked }: RadioButtonProps) {
+  return (
+    <Label>
+      {children}
+      <RadioInput type="radio" name="invite" value={value} defaultChecked={defaultChecked} />
+    </Label>
+  );
+}
+
+const { color } = DESIGN_TOKEN;
+
+const Label = styled.label`
+  display: flex;
+  justify-content: space-between;
+`; // 폰트는 디자인 추가되면 더 수정해야 할 듯
+
+const RadioInput = styled.input`
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 4.3rem;
+  border: 0.1rem solid ${color.gray[2]};
+  outline: none;
+
+  &:checked {
+    background-color: ${color.secondary};
+    border: 0.3rem solid white;
+    box-shadow: 0 0 0 0.1rem ${color.secondary};
+  }
+`;
+
+// 아래 예시처럼 사용하면 됩니다.
+
+// import RadioButton from "@/components/commons/RadioButton";
+
+// //mock 데이터
+// import { recruitedStudyList } from "@/lib/mock/recruiteStudyList";
+
+// export default function StudyList() {
+//   const [firstItem, ...otherItems] = recruitedStudyList.result.recruitedStudyList;
+
+//   return (
+//     <div>
+//       <RadioButton value={firstItem.title} defaultChecked>
+//         {firstItem.title}
+//       </RadioButton>
+//       {otherItems.map(({ postId, title }) => (
+//         <RadioButton key={postId} value={title}>
+//           {title}
+//         </RadioButton>
+//       ))}
+//     </div>
+//   );
+// }

--- a/co-kkiri/src/lib/mock/recruiteStudyList.ts
+++ b/co-kkiri/src/lib/mock/recruiteStudyList.ts
@@ -1,0 +1,23 @@
+interface RecruitedStudy {
+  postId: number;
+  title: string;
+  //status: string; // 필요한지 논의 필요, 모집 완료 기능이 있기 때문에 필요할 듯
+  //recruitEndAt: string;
+}
+
+interface MyRecruitedStudyList {
+  result: {
+    recruitedStudyList: RecruitedStudy[];
+  };
+}
+
+export const recruitedStudyList: MyRecruitedStudyList = {
+  result: {
+    recruitedStudyList: [
+      { postId: 1, title: "자바스크립트 스터디1" },
+      { postId: 2, title: "자바스크립트 스터디2" },
+      { postId: 3, title: "자바스크립트 스터디3" },
+      { postId: 4, title: "자바스크립트 스터디4" },
+    ],
+  },
+};


### PR DESCRIPTION
### 📌요구사항
- [x] RadioButton 컴포넌트 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

사용하실때 아래 처럼 사용하시면 됩니다.

``` 
import RadioButton from "@/components/commons/RadioButton";

 //mock 데이터
 import { recruitedStudyList } from "@/lib/mock/recruiteStudyList";

 export default function StudyList() {
   // 첫번째 항목이 처음에 자동 선택되도록
   const [firstItem, ...otherItems] = recruitedStudyList.result.recruitedStudyList; 

   return (
     <div>
       <RadioButton value={firstItem.title} defaultChecked>
         {firstItem.title}
       </RadioButton>
       {otherItems.map(({ postId, title }) => (
         <RadioButton key={postId} value={title}>
           {title}
         </RadioButton>
       ))}
     </div>
   );
 }
```

### 📌스크린샷 / 테스트결과 (선택)


https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/8a41cd4d-929f-4012-a70f-3390c94dea49





### 📌이슈 번호
close #64