### PR TITLE
Refactor: zustand로 isSideBarOpen 상태 관리 / desktop 사이즈 일때 narrow 사이즈 고려 

### DIFF
--- a/co-kkiri/src/components/commons/Card/Card.styled.ts
+++ b/co-kkiri/src/components/commons/Card/Card.styled.ts
@@ -8,7 +8,7 @@ interface PageProp {
 }
 
 interface ContainerProps extends PageProp {
-  $isSideBarOpen: boolean;
+  $isSidebarOpenNarrow: boolean;
 }
 
 const {
@@ -17,12 +17,12 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const desktopWidthByPage = ($isSideBarOpen: boolean, $page: PageType) => {
+const desktopWidthByPage = ($isSidebarOpenNarrow: boolean, $page: PageType) => {
   switch ($page) {
     case "home":
-      return $isSideBarOpen ? "44.5rem" : "26.5rem";
+      return $isSidebarOpenNarrow ? "44.5rem" : "26.5rem";
     case "studyList":
-      return $isSideBarOpen ? "29rem" : "26.5rem";
+      return $isSidebarOpenNarrow ? "29rem" : "26.5rem";
     default:
       return "26.5rem";
   }
@@ -39,8 +39,8 @@ const mobileWidthByPage = ($page: PageType) => {
   }
 };
 
-const widthForDevice = ({ $isSideBarOpen, $page }: ContainerProps) => {
-  const desktopWidth = desktopWidthByPage($isSideBarOpen, $page);
+const widthForDevice = ({ $isSidebarOpenNarrow, $page }: ContainerProps) => {
+  const desktopWidth = desktopWidthByPage($isSidebarOpenNarrow, $page);
   const mobileWidth = mobileWidthByPage($page);
 
   return css`

--- a/co-kkiri/src/components/commons/Card/Card.styled.ts
+++ b/co-kkiri/src/components/commons/Card/Card.styled.ts
@@ -8,7 +8,7 @@ interface PageProp {
 }
 
 interface ContainerProps extends PageProp {
-  $isSidebarOpen: boolean;
+  $isSideBarOpen: boolean;
 }
 
 const {
@@ -17,12 +17,12 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const desktopWidthByPage = ($isSidebarOpen: boolean, $page: PageType) => {
+const desktopWidthByPage = ($isSideBarOpen: boolean, $page: PageType) => {
   switch ($page) {
     case "home":
-      return $isSidebarOpen ? "44.5rem" : "26.5rem";
+      return $isSideBarOpen ? "44.5rem" : "26.5rem";
     case "studyList":
-      return $isSidebarOpen ? "29rem" : "26.5rem";
+      return $isSideBarOpen ? "29rem" : "26.5rem";
     default:
       return "26.5rem";
   }
@@ -39,8 +39,8 @@ const mobileWidthByPage = ($page: PageType) => {
   }
 };
 
-const widthForDevice = ({ $isSidebarOpen, $page }: ContainerProps) => {
-  const desktopWidth = desktopWidthByPage($isSidebarOpen, $page);
+const widthForDevice = ({ $isSideBarOpen, $page }: ContainerProps) => {
+  const desktopWidth = desktopWidthByPage($isSideBarOpen, $page);
   const mobileWidth = mobileWidthByPage($page);
 
   return css`

--- a/co-kkiri/src/components/commons/Card/index.tsx
+++ b/co-kkiri/src/components/commons/Card/index.tsx
@@ -60,7 +60,7 @@ export default function Card({ page = "home", cardData }: CardProps) {
             <S.ProjectChip>
               <ProjectChip label={type} />
             </S.ProjectChip>
-            <Scrap wasScraped={isScraped} width={36} />
+            <Scrap isScraped={isScraped} width={36} />
           </S.TypeWrapper>
         )}
         <S.UpperBox $page={page}>
@@ -68,7 +68,7 @@ export default function Card({ page = "home", cardData }: CardProps) {
             <S.HeaderPadding $page={page}>
               <Header deadline={recruitEndAt} progressWay={progressWay} />
             </S.HeaderPadding>
-            {page === "home" && <Scrap wasScraped={isScraped} width={28} />}
+            {page === "home" && <Scrap isScraped={isScraped} width={28} />}
           </S.HeaderWrapper>
           <S.ContentWrapper>
             <Title title={title} />

--- a/co-kkiri/src/components/commons/Card/index.tsx
+++ b/co-kkiri/src/components/commons/Card/index.tsx
@@ -1,6 +1,5 @@
 import * as S from "./Card.styled";
 import { Link } from "react-router-dom";
-import useSideBarStore from "@/stores/sideBarStore";
 
 import Header from "./Header";
 import Title from "./Title";
@@ -11,6 +10,7 @@ import Stacks from "../Stacks";
 import Count from "../Count";
 import UserInfo from "../UserInfo";
 
+import useResponsiveSidebar from "@/hooks/useResponsiveSideBar";
 import { ICONS } from "@/constants/icons";
 
 //임시
@@ -35,7 +35,7 @@ interface CardProps {
 }
 
 export default function Card({ page = "home", cardData }: CardProps) {
-  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+  const isSidebarOpenNarrow = useResponsiveSidebar();
 
   const {
     id,
@@ -54,7 +54,7 @@ export default function Card({ page = "home", cardData }: CardProps) {
 
   return (
     <Link to={`/list/${id}`}>
-      <S.Container $page={page} $isSideBarOpen={isSideBarOpen}>
+      <S.Container $page={page} $isSidebarOpenNarrow={isSidebarOpenNarrow}>
         {page === "studyList" && (
           <S.TypeWrapper>
             <S.ProjectChip>

--- a/co-kkiri/src/components/commons/Card/index.tsx
+++ b/co-kkiri/src/components/commons/Card/index.tsx
@@ -1,5 +1,6 @@
 import * as S from "./Card.styled";
 import { Link } from "react-router-dom";
+import useSideBarStore from "@/stores/sideBarStore";
 
 import Header from "./Header";
 import Title from "./Title";
@@ -34,8 +35,8 @@ interface CardProps {
 }
 
 export default function Card({ page = "home", cardData }: CardProps) {
-  //임시
-  const isSidebarOpen = false;
+  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+
   const {
     id,
     type,
@@ -53,7 +54,7 @@ export default function Card({ page = "home", cardData }: CardProps) {
 
   return (
     <Link to={`/list/${id}`}>
-      <S.Container $page={page} $isSidebarOpen={isSidebarOpen}>
+      <S.Container $page={page} $isSideBarOpen={isSideBarOpen}>
         {page === "studyList" && (
           <S.TypeWrapper>
             <S.ProjectChip>

--- a/co-kkiri/src/components/commons/Scrap.tsx
+++ b/co-kkiri/src/components/commons/Scrap.tsx
@@ -4,18 +4,17 @@ import { useToggle } from "usehooks-ts";
 
 //임시
 interface ScrapProps {
-  wasScraped?: boolean;
+  isScraped?: boolean;
   width?: number;
-  onClick?: () => void;
 }
 
 /**
  *
  * @property width - px단위
  * */
-export default function Scrap({ wasScraped = false, width }: ScrapProps) {
-  const [isScraped, toggle] = useToggle(wasScraped);
-  const scrapIcon = isScraped ? ICONS.scrapFull : ICONS.scrapEmpty;
+export default function Scrap({ isScraped = false, width }: ScrapProps) {
+  const [isScrapedValue, toggle] = useToggle(isScraped);
+  const scrapIcon = isScrapedValue ? ICONS.scrapFull : ICONS.scrapEmpty;
 
   const handleScrapClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();

--- a/co-kkiri/src/components/commons/Scrap.tsx
+++ b/co-kkiri/src/components/commons/Scrap.tsx
@@ -32,6 +32,7 @@ export default function Scrap({ wasScraped = false, width }: ScrapProps) {
 
 const Wrapper = styled.div<{ $width?: number }>`
   width: ${({ $width }) => ($width ? `${$width / 10}rem` : "100%")};
+  cursor: pointer;
 `;
 
 const ScrapIcon = styled.img`

--- a/co-kkiri/src/components/commons/Stack.tsx
+++ b/co-kkiri/src/components/commons/Stack.tsx
@@ -8,14 +8,11 @@ interface StackProps {
 }
 
 export default function Stack({ stack }: StackProps) {
-  const icon = stack ? STACK_ICONS[stack] : undefined;
+  //임시
+  const icon = stack && STACK_ICONS[stack] ? STACK_ICONS[stack] : ICONS.questionMark;
   return (
     <Background>
-      {icon ? (
-        <StackIcon src={icon.src} alt={icon.alt} />
-      ) : (
-        <EmptyIcon src={ICONS.questionMark.src} alt={ICONS.questionMark.alt} />
-      )}
+      <Icon src={icon.src} alt={icon.alt} />
     </Background>
   );
 }
@@ -28,17 +25,13 @@ const Background = styled.div`
   width: 3.6rem;
   height: 3.6rem;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
-const EmptyIcon = styled.img`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-`;
-
-const StackIcon = styled(EmptyIcon)`
-  //임의 값 -> 디자인 완성되면 수정할 것
-  width: 2.4rem;
-  height: 2.4rem;
+const Icon = styled.img`
+  //임시
+  max-width: 2.4rem;
+  max-height: 2.4rem;
 `;

--- a/co-kkiri/src/components/commons/Stack.tsx
+++ b/co-kkiri/src/components/commons/Stack.tsx
@@ -12,9 +12,9 @@ export default function Stack({ stack }: StackProps) {
   return (
     <Background>
       {icon ? (
-        <Icon src={icon.src} alt={icon.alt} />
+        <StackIcon src={icon.src} alt={icon.alt} />
       ) : (
-        <Icon src={ICONS.questionMark.src} alt={ICONS.questionMark.alt} />
+        <EmptyIcon src={ICONS.questionMark.src} alt={ICONS.questionMark.alt} />
       )}
     </Background>
   );
@@ -30,9 +30,15 @@ const Background = styled.div`
   position: relative;
 `;
 
-const Icon = styled.img`
+const EmptyIcon = styled.img`
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+`;
+
+const StackIcon = styled(EmptyIcon)`
+  //임의 값 -> 디자인 완성되면 수정할 것
+  width: 2.4rem;
+  height: 2.4rem;
 `;

--- a/co-kkiri/src/components/domains/home/Banner.tsx
+++ b/co-kkiri/src/components/domains/home/Banner.tsx
@@ -1,8 +1,9 @@
 import { Link } from "react-router-dom";
-import useSideBarStore from "@/stores/sideBarStore";
 
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
+
+import useResponsiveSidebar from "@/hooks/useResponsiveSideBar";
 
 //임시
 interface Image {
@@ -16,11 +17,11 @@ interface BannerProps {
 }
 
 export default function Banner({ image, path }: BannerProps) {
-  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+  const isSidebarOpenNarrow = useResponsiveSidebar();
 
   return (
     <Link to={path}>
-      <Background $isSideBarOpen={isSideBarOpen}>
+      <Background $isSidebarOpenNarrow={isSidebarOpenNarrow}>
         <img src={image.src} alt={image.alt} />
       </Background>
     </Link>
@@ -32,12 +33,12 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const Background = styled.figure<{ $isSideBarOpen?: boolean }>`
+const Background = styled.figure<{ $isSidebarOpenNarrow: boolean }>`
   background-color: ${color.primary[3]};
   border-radius: 2rem;
 
   ${desktop} {
-    width: ${({ $isSideBarOpen }) => ($isSideBarOpen ? 29 : 36)}rem;
+    width: ${({ $isSidebarOpenNarrow }) => ($isSidebarOpenNarrow ? 29 : 36)}rem;
     height: 24rem;
   }
 

--- a/co-kkiri/src/components/domains/home/Banner.tsx
+++ b/co-kkiri/src/components/domains/home/Banner.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import useSideBarStore from "@/stores/sideBarStore";
 
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
@@ -15,12 +16,11 @@ interface BannerProps {
 }
 
 export default function Banner({ image, path }: BannerProps) {
-  //임시
-  const isSidebarOpen = false;
+  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
 
   return (
     <Link to={path}>
-      <Background $isSidebarOpen={isSidebarOpen}>
+      <Background $isSideBarOpen={isSideBarOpen}>
         <img src={image.src} alt={image.alt} />
       </Background>
     </Link>
@@ -32,12 +32,12 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const Background = styled.figure<{ $isSidebarOpen?: boolean }>`
+const Background = styled.figure<{ $isSideBarOpen?: boolean }>`
   background-color: ${color.primary[3]};
   border-radius: 2rem;
 
   ${desktop} {
-    width: ${({ $isSidebarOpen }) => ($isSidebarOpen ? 29 : 36)}rem;
+    width: ${({ $isSideBarOpen }) => ($isSideBarOpen ? 29 : 36)}rem;
     height: 24rem;
   }
 

--- a/co-kkiri/src/components/domains/home/Cards.tsx
+++ b/co-kkiri/src/components/domains/home/Cards.tsx
@@ -1,9 +1,8 @@
-import useSideBarStore from "@/stores/sideBarStore";
-
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
 
 import Card from "@/components/commons/Card";
+import useResponsiveSidebar from "@/hooks/useResponsiveSideBar";
 
 //임시
 interface CardData {
@@ -26,12 +25,12 @@ interface CardsProps {
 }
 
 export default function Cards({ cardDataList }: CardsProps) {
-  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+  const isSidebarOpenNarrow = useResponsiveSidebar();
 
   return (
-    <Wrapper $isSideBarOpen={isSideBarOpen}>
+    <Wrapper $isSidebarOpenNarrow={isSidebarOpenNarrow}>
       {cardDataList.map((cardData) => (
-        <Card key={cardData.id} page="home" cardData={cardData} />
+        <Card key={cardData.id} page="studyList" cardData={cardData} />
       ))}
     </Wrapper>
   );
@@ -42,13 +41,13 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const Wrapper = styled.div<{ $isSideBarOpen: boolean }>`
+const Wrapper = styled.div<{ $isSidebarOpenNarrow: boolean }>`
   display: flex;
 
   ${desktop} {
     gap: 2rem;
-    ${({ $isSideBarOpen }) =>
-      $isSideBarOpen
+    ${({ $isSidebarOpenNarrow }) =>
+      $isSidebarOpenNarrow
         ? `  display: grid;
     grid-template:
       1fr 1fr /

--- a/co-kkiri/src/components/domains/home/Cards.tsx
+++ b/co-kkiri/src/components/domains/home/Cards.tsx
@@ -30,7 +30,7 @@ export default function Cards({ cardDataList }: CardsProps) {
   return (
     <Wrapper $isSidebarOpenNarrow={isSidebarOpenNarrow}>
       {cardDataList.map((cardData) => (
-        <Card key={cardData.id} page="studyList" cardData={cardData} />
+        <Card key={cardData.id} page="home" cardData={cardData} />
       ))}
     </Wrapper>
   );

--- a/co-kkiri/src/components/domains/home/Cards.tsx
+++ b/co-kkiri/src/components/domains/home/Cards.tsx
@@ -1,3 +1,5 @@
+import useSideBarStore from "@/stores/sideBarStore";
+
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
 
@@ -24,11 +26,10 @@ interface CardsProps {
 }
 
 export default function Cards({ cardDataList }: CardsProps) {
-  //임시
-  const isSidebarOpen = false;
+  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
 
   return (
-    <Wrapper $isSidebarOpen={isSidebarOpen}>
+    <Wrapper $isSideBarOpen={isSideBarOpen}>
       {cardDataList.map((cardData) => (
         <Card key={cardData.id} page="home" cardData={cardData} />
       ))}
@@ -41,13 +42,13 @@ const {
   mediaQueries: { desktop, tablet, mobile },
 } = DESIGN_TOKEN;
 
-const Wrapper = styled.div<{ $isSidebarOpen: boolean }>`
+const Wrapper = styled.div<{ $isSideBarOpen: boolean }>`
   display: flex;
 
   ${desktop} {
     gap: 2rem;
-    ${({ $isSidebarOpen }) =>
-      $isSidebarOpen
+    ${({ $isSideBarOpen }) =>
+      $isSideBarOpen
         ? `  display: grid;
     grid-template:
       1fr 1fr /

--- a/co-kkiri/src/hooks/useResponsiveSideBar.ts
+++ b/co-kkiri/src/hooks/useResponsiveSideBar.ts
@@ -1,0 +1,13 @@
+import { useWindowSize } from "usehooks-ts";
+import useSideBarStore from "@/stores/sideBarStore";
+
+const useResponsiveSidebar = () => {
+  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+  const { width: screenWidth } = useWindowSize();
+
+  const isSidebarOpenNarrow = isSideBarOpen && screenWidth < 1410;
+
+  return isSidebarOpenNarrow;
+};
+
+export default useResponsiveSidebar;

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -1,22 +1,19 @@
+import { Outlet } from "react-router-dom";
+import useSideBarStore from "@/stores/sideBarStore";
+import styled, { keyframes } from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
 import Gnb from "@/components/commons/Gnb";
 import SideBar from "@/components/commons/SideBar";
-import DESIGN_TOKEN from "@/styles/tokens";
-import { useState } from "react";
-import { Outlet } from "react-router-dom";
-import styled, { keyframes } from "styled-components";
 
 export default function Navigation() {
-  const [isSideBarOpen, setIsSideBarOpen] = useState<boolean>(false);
-
-  const handleSideBarOpen = () => {
-    setIsSideBarOpen(!isSideBarOpen);
-  };
+  const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
+  const toggleSideBar = useSideBarStore((state) => state.toggleSideBar);
 
   return (
     <>
-      <Gnb onSideBarClick={handleSideBarOpen} />
+      <Gnb onSideBarClick={toggleSideBar} />
       <SideBarWrapper $isOpen={isSideBarOpen}>
-        <SideBar onClick={handleSideBarOpen} />
+        <SideBar onClick={toggleSideBar} />
       </SideBarWrapper>
       <OutletWrapper $isOpen={isSideBarOpen}>
         <Outlet />

--- a/co-kkiri/src/lib/mock/mainStudyList.ts
+++ b/co-kkiri/src/lib/mock/mainStudyList.ts
@@ -35,7 +35,7 @@ export const mainStudyList: MainStudyList = {
         isScraped: true,
         progressWay: "온라인",
         title: "프론트엔드 기초 스터디",
-        position: ["개발자"],
+        position: ["프론트엔드", "안드로이드", "디자이너"],
         stack: ["HTML", "CSS", "JavaScript"],
         memberNickname: "개발자A",
         memberProfileImg: "",

--- a/co-kkiri/src/stores/sideBarStore.ts
+++ b/co-kkiri/src/stores/sideBarStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SideBarState {
+  isSideBarOpen: boolean;
+  toggleSideBar: () => void;
+}
+
+const useSideBarStore = create<SideBarState>()((set) => ({
+  isSideBarOpen: false,
+  toggleSideBar: () => set((state) => ({ isSideBarOpen: !state.isSideBarOpen })),
+}));
+
+export default useSideBarStore;


### PR DESCRIPTION
### 📌요구사항
- [x] zustand로 isSideBarOpen 상태 관리 하기
- [x] desktop 사이즈일 때 narrow 사이즈 고려해서 반응형 구현하기
- [x] Stack 컴포넌트의 img 최소 사이즈 정해주기
- [x] Scrap 컴포넌트의 변수명 변경하기

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- /src/stores/sideBarStore.ts 생성 후 isSideBarOpen 변수 및 toggleSideBar 함수 전역 관리
- /src/hooks/useResponsiveSideBar.ts 생성 후 현재 스크린 상태를 판단하는 hook 구현
  - `useResponsiveSidebar` hook은`isSidebarOpenNarrow` 변수를 반환함
  - ` const isSidebarOpenNarrow = isSideBarOpen && screenWidth < 1410;` 이므로 사이드바가 열렸고, 스크린 width가 1410px 이하일 경우 true를 반환함
- Stack 컴포넌트 리팩토링 완료 -> 디자인 시안 나오면 width와 height 변경해야 함
- Scrap 컴포넌트의 wasScraped 변수 대신 isScraped와 isScrpedValue를 사용하는 것으로 변경

### 📌스크린샷 / 테스트결과 (선택)
- home 페이지 사이드바 반응형

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/dca3f1ec-7acb-49fb-ab60-5a69c549351a

- Stack 컴포넌트

![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/93c1ec55-31ad-49ce-85d3-c4f6e2ef412d)

- Scrap 컴포넌트

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/b386a583-ccbf-476a-9364-fb799b132bfd

### 📌이슈 번호
