### PR TITLE
Feat:  OneLinerInput, TextInput 구현

### DIFF
--- a/co-kkiri/src/components/commons/OneLinerInput.tsx
+++ b/co-kkiri/src/components/commons/OneLinerInput.tsx
@@ -1,0 +1,58 @@
+import { InputHTMLAttributes, forwardRef } from "react";
+import { styled } from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+interface OneLinerInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+const OneLinerInput = forwardRef<HTMLInputElement, OneLinerInputProps>(
+  ({ label, id, placeholder, value, maxLength, onChange, onBlur }, ref) => {
+    return (
+      <Wrapper>
+        <Label htmlFor={id}>{label}</Label>
+        <Input
+          id={id}
+          placeholder={placeholder}
+          value={value}
+          maxLength={maxLength}
+          onChange={onChange}
+          onBlur={onBlur}
+          ref={ref}
+        />
+      </Wrapper>
+    );
+  },
+);
+
+export default OneLinerInput;
+
+const {
+  color,
+  typography: { font16Bold, font16Medium },
+} = DESIGN_TOKEN;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+`;
+
+const Label = styled.label`
+  color: ${color.black[1]};
+  ${font16Bold};
+`;
+
+const Input = styled.input`
+  ${font16Medium};
+  background: ${color.white};
+  border: 1px solid ${color.gray[2]};
+  border-radius: 0.5rem;
+  color: ${color.black[1]};
+  padding: 1.4rem 2rem 1.5rem;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/co-kkiri/src/components/commons/OneLinerInput.tsx
+++ b/co-kkiri/src/components/commons/OneLinerInput.tsx
@@ -4,10 +4,11 @@ import DESIGN_TOKEN from "@/styles/tokens";
 
 interface OneLinerInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
+  helperText?: string;
 }
 
 const OneLinerInput = forwardRef<HTMLInputElement, OneLinerInputProps>(
-  ({ label, id, placeholder, value, maxLength, onChange, onBlur }, ref) => {
+  ({ label, id, placeholder, value, maxLength, helperText, onChange, onBlur }, ref) => {
     return (
       <Wrapper>
         <Label htmlFor={id}>{label}</Label>
@@ -20,6 +21,7 @@ const OneLinerInput = forwardRef<HTMLInputElement, OneLinerInputProps>(
           onBlur={onBlur}
           ref={ref}
         />
+        <p>{helperText}</p> {/*아직 스타일은 적용하지 않음*/}
       </Wrapper>
     );
   },

--- a/co-kkiri/src/components/domains/myPage/TextInput.tsx
+++ b/co-kkiri/src/components/domains/myPage/TextInput.tsx
@@ -1,0 +1,27 @@
+import { Control, Controller } from "react-hook-form";
+import OneLinerInput from "@/components/commons/OneLinerInput";
+import { CONDITIONS, LABEL } from "@/constants/textInputRules";
+
+interface FormData {
+  nickname: string;
+  link: string;
+  introduction: string;
+}
+
+interface TextInputProps {
+  name: "nickname" | "link" | "introduction";
+  control: Control<FormData>;
+}
+
+export default function TextInput({ name, control }: TextInputProps) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={CONDITIONS[name]}
+      render={({ field, fieldState }) => (
+        <OneLinerInput label={LABEL[name]} helperText={fieldState.error?.message} {...field} />
+      )}
+    />
+  );
+}

--- a/co-kkiri/src/constants/textInputRules.ts
+++ b/co-kkiri/src/constants/textInputRules.ts
@@ -1,0 +1,23 @@
+interface ValidationRule {
+  required?: string;
+  maxLength?: { value: number; message: string };
+  pattern?: { value: RegExp; message: string };
+}
+
+export const CONDITIONS: Record<string, ValidationRule> = {
+  nickname: {
+    required: "닉네임을 입력해 주세요",
+    maxLength: { value: 10, message: "최대 10글자까지 쓸 수 있어요" },
+  },
+  link: {
+    pattern: {
+      value: /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/, // 해당 정규식은 임시입니다.
+      message: "올바른 url 형식이 아닙니다.",
+    },
+  },
+  introduction: {
+    maxLength: { value: 30, message: "최대 30글자까지 쓸 수 있어요" },
+  },
+};
+
+export const LABEL = { nickname: "닉네임", link: "대표 링크", introduction: "한 줄 소개" };


### PR DESCRIPTION
### 📌요구사항
- [x] OneLinerInput 구현 -> 다양한 text input 컴포넌트의 베이스가 되는 컴포넌트
- [x] TextInput 구현 -> OneLinerInput에 ract hook form 적용한 컴포넌트

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- OneLinerInput 구현 후 정보 수정 모달에 들어가는 input 컴포넌트 3개를 따로 구현할 계획이었으나 
TextInput 하나로 3개를 커버할 수 있도록 변경했음

#### 알림
- OneLinerInput의 사용되지 않는 prop들은 추후 삭제하거나 필요시 남겨놓을 예정임
- 유효한 url임을 검사하는 정규식은 임시임
- 아무리 생각해도 error메세지가 필요할 것 같아서 기능만 구현하고 스타일은 적용하지 않음

#### 팀원들의 의견이 필요한 것들
- width를 100%로 지정함
- maxLength를 감지하기 위해 mode는 onChange로 했음
- 주현님한테 OneLinerInput에 ...props에 대해 물어볼 것
- 한 줄 소개와 대표 링크 필수 여부 논의할 것
- 한 줄 소개 input이 반응형 mobile일때 줄바꿈이 되는 기능은 구현하지 못했음

#### 덜 한 부분
- Modal Textarea에 react hook form 적용하는 거는 아직 못했음

#### 사용방법
```js
import { useForm } from "react-hook-form";
import TextInput from "@/components/domains/myPage/TextInput";

export default function StudyList() {
  const { control, handleSubmit } = useForm({
    mode: "onChange",
    defaultValues: {
      nickname: "코끼리", // 이 값은 기존 정보로 api에서 받아온 data로 대체하면 됩니다.
      link: "https://www.naver.com/",
      introduction: "안녕하세요. 프론트엔드 코끼리입니다.",
    },
  });

  const onSubmit = (data: unknown) => {
    console.log(data);
  };

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <TextInput name="nickname" control={control} />
      <TextInput name="link" control={control} />
      <TextInput name="introduction" control={control} />
      <button type="submit">제출</button>
    </form>
  );
}
```

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/1e36b643-14cc-4c2e-ba82-04460be6e407

### 📌이슈 번호
close #74 