### PR TITLE
Fix: 새로고침 시 SideBar 깜빡임 현상 해결

### DIFF
--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -25,13 +25,15 @@ export default function Navigation() {
   return (
     <>
       <Gnb onSideBarClick={handleSideBarOpen} />
-      <SideBarWrapper $isOpen={isSideBarOpen}>
-        {!isTabletOrMobile ? (
-          <SideBar onClose={() => {}} />
-        ) : (
-          isOpen && <SideBar onClick={handleSideBarOpen} onClose={handleSideBarOpen} />
-        )}
-      </SideBarWrapper>
+      {isSideBarOpen && (
+        <SideBarWrapper $isOpen={isSideBarOpen}>
+          {!isTabletOrMobile ? (
+            <SideBar onClose={() => {}} />
+          ) : (
+            isOpen && <SideBar onClick={handleSideBarOpen} onClose={handleSideBarOpen} />
+          )}
+        </SideBarWrapper>
+      )}
       <OutletWrapper $isOpen={isSideBarOpen}>
         <Outlet />
       </OutletWrapper>


### PR DESCRIPTION
### 📌요구사항
- [x] 새로고침 시 SideBar 깜빡임 현상 해결

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
1. 화면에서 그려지고 렌더링 하는 과정에서 DOM 트리 생성 과정에선 isSideBarOpen 의 존재를 모름 →화면에서 props와 state와 상관없이 컴포넌트를 전부 보여줌 (사이드바 보임)
2. 렌더링 과정에서 isSideBarOpen 의 존재를 알게되면 state를 반영함(디폴트 값인 false로)  → 화면상에선 사라지게 되는 거죠 (사이드바 사라짐)
3. 1번 2번이 진행되면서 깜빡거림 

해결책 →  isSideBarOpen가 없으면 SideBar를 아예 보여주지 않기

### 📌스크린샷 / 테스트결과 (선택)
- before

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/443e4494-16c3-474d-a2cc-7091f6c68dce

- after

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/45821e19-1376-412b-8e08-7a7d1f093a3e



### 📌이슈 번호
close #90 