### PR TITLE
Fix: prettier 미적용 코드 수정 및 ProjectDetailCard number rendering 추가

### DIFF
--- a/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/ProjectChip.tsx
@@ -8,7 +8,7 @@ interface ProjectChipProps {
 }
 
 export default function ProjectChip({ label }: ProjectChipProps) {
-  const getTypeLabel = (type: "STUDY" | "PROJECT") => {
+  const getTypeLabel = (type: CategoryList) => {
     switch (type) {
       case "STUDY":
         return "스터디";
@@ -16,10 +16,10 @@ export default function ProjectChip({ label }: ProjectChipProps) {
         return "프로젝트";
     }
   };
-  return <Container label={getTypeLabel(label)} />;
+  return <Container label={getTypeLabel(label)} $labelDesign={label} />;
 }
 
-type ProjectVariant = "스터디" | "프로젝트";
+type ProjectVariant = CategoryList;
 
 const ProjectChipStyle = css`
   padding: 0.6rem 3rem;
@@ -27,18 +27,18 @@ const ProjectChipStyle = css`
 `;
 
 const VARIANT_STYLE: VariantStyle<ProjectVariant> = {
-  스터디: css`
+  STUDY: css`
     background-color: #daf4af;
     color: #588f00;
     ${ProjectChipStyle}
   `,
-  프로젝트: css`
+  PROJECT: css`
     background-color: #ffdbe4;
     color: #c71b44;
     ${ProjectChipStyle}
   `,
 };
 
-const Container = styled(DefaultChip)<{ label: ProjectVariant }>`
-  ${({ label }) => VARIANT_STYLE[label]}
+const Container = styled(DefaultChip)<{ $labelDesign: ProjectVariant }>`
+  ${({ $labelDesign }) => VARIANT_STYLE[$labelDesign]}
 `;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -5,71 +5,85 @@ import styled from "styled-components";
 import { RenderType } from "./types";
 
 export interface ProjectDetailRowProps {
-    label: string;
-    content: string | string[];
-    renderType: RenderType;
+  label: string;
+  content: string | string[];
+  renderType: RenderType;
 }
 
 export default function ProjectDetailRow({ label, content, renderType }: ProjectDetailRowProps) {
-
-    //Chip이랑 Icon은 배열이어야만 정상적으로 render함
-    const renderContent = useCallback(() => {
-        switch (renderType) {
-            case "text":
-                return <p>{content}</p>;
-                break;
-            case "positionChip":
-                if (Array.isArray(content)) {
-                    return <div className="chip position">{content.map((item) => <PositionChip key={item} label={item} />)}</div>
-                }
-                break;
-            case "stackIcon":
-                if (Array.isArray(content)) {
-                    //TODO: 임시, 추후 stackIcon으로 변경
-                    return <div className="chip stack">{content.map((item) => <div key={item}><img src={item}/></div>)}</div>
-                }
+  //Chip이랑 Icon은 배열이어야만 정상적으로 render함
+  const renderContent = useCallback(() => {
+    switch (renderType) {
+      case "text":
+        return <p>{content}</p>;
+        break;
+      case "positionChip":
+        if (Array.isArray(content)) {
+          return (
+            <div className="chip position">
+              {content.map((item) => (
+                <PositionChip key={item} label={item} />
+              ))}
+            </div>
+          );
         }
-    }, [content, renderType])
+        break;
+      case "stackIcon":
+        if (Array.isArray(content)) {
+          //TODO: 임시, 추후 stackIcon으로 변경
+          return (
+            <div className="chip stack">
+              {content.map((item) => (
+                <div key={item}>
+                  <img src={item} />
+                </div>
+              ))}
+            </div>
+          );
+        }
+    }
+  }, [content, renderType]);
 
-    return (
-        <Container>
-            <div className="label"><span>{label}</span></div>
-            {renderContent()}
-        </Container>
-    )
-
+  return (
+    <Container>
+      <div className="label">
+        <span>{label}</span>
+      </div>
+      {renderContent()}
+    </Container>
+  );
 }
 
 const { color, typography } = DESIGN_TOKEN;
 
 const Container = styled.div`
-    width: 100%;
+  width: 100%;
 
+  display: flex;
+  align-items: flex-start;
+
+  ${typography.font16Semibold}
+
+  & > .label {
+    width: 10rem;
+    color: ${color.gray[1]};
+  }
+
+  & > .text {
+    color: ${color.black[1]};
+  }
+
+  & > .chip {
     display: flex;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    flex-shrink: 1;
+  }
 
-    ${typography.font16Semibold}
+  & > .chip.position {
+    gap: 0.6rem;
+  }
 
-    & > .label{
-        width: 10rem;
-        color: ${color.gray[1]};
-    }
-
-    & > .text{
-        color: ${color.black[1]};
-    }
-
-    & > .chip{
-        display: flex;
-        flex-wrap: wrap;
-        flex-shrink: 1;
-    }
-
-    & > .chip.position{
-        gap: .6rem;
-    }
-
-    & > .chip.stack{
-        gap: .8rem;
-    }
+  & > .chip.stack {
+    gap: 0.8rem;
+  }
 `;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -2,11 +2,11 @@ import PositionChip from "@/components/commons/Chips/PositionChip";
 import DESIGN_TOKEN from "@/styles/tokens";
 import { useCallback } from "react";
 import styled from "styled-components";
-import { RenderType } from "./types";
+import { ContentType, RenderType } from "./types";
 
 export interface ProjectDetailRowProps {
   label: string;
-  content: string | string[];
+  content: ContentType;
   renderType: RenderType;
 }
 

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -16,7 +16,8 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
     switch (renderType) {
       case "text":
         return <p>{content}</p>;
-        break;
+      case "personNumber":
+        return <p>{content}명</p>;
       case "positionChip":
         if (Array.isArray(content)) {
           return (

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailTable.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailTable.tsx
@@ -1,15 +1,15 @@
 import styled from "styled-components";
 
 interface ProjectDetailTableProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 
-export default function ProjectDetailTable({children}: ProjectDetailTableProps) {
-    return <Container>{children}</Container>;
+export default function ProjectDetailTable({ children }: ProjectDetailTableProps) {
+  return <Container>{children}</Container>;
 }
 
 const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 2.4rem;
-`
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+`;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
@@ -6,91 +6,93 @@ import { ProjectDetailConfig, ProjectDetailContentType } from "./types";
 import ProjectDetailRow from "./ProjectDetailRow";
 
 interface ProjectDetailCardProps extends ProjectDetailContentType {
-    ProjectCategory: ProjectType;
+  ProjectCategory: ProjectType;
 }
 
-
 export default function ProjectDetailCard({ ProjectCategory, ...projectDetailContents }: ProjectDetailCardProps) {
+  // 이 친구가 여기 있으면 안될 것 같은데 추후에 코드를 수정해서 밖으로 빼던 해야할 듯 합니다
+  const projectDetailConfig: ProjectDetailConfig = {
+    recruitEndAt: {
+      label: "모집 마감",
+      content: projectDetailContents.recruitEndAt,
+      renderType: "text",
+    },
+    progressPeriod: {
+      label: "진행 기간",
+      content: projectDetailContents.progressPeriod,
+      renderType: "text",
+    },
+    progressWay: {
+      label: "진행 방식",
+      content: projectDetailContents.progressWay,
+      renderType: "text",
+    },
+    contactWay: {
+      label: "연락 방식",
+      content: projectDetailContents.contactWay,
+      renderType: "text",
+    },
+    capacity: {
+      label: "모집 인원",
+      content: projectDetailContents.capacity,
+      renderType: "text",
+    },
+    positions: {
+      label: "모집 포지션",
+      content: projectDetailContents.positions,
+      renderType: "positionChip",
+    },
+    stacks: {
+      label: "기술 스택",
+      content: projectDetailContents.stacks,
+      renderType: "stackIcon",
+    },
+  };
 
-    // 이 친구가 여기 있으면 안될 것 같은데 추후에 코드를 수정해서 밖으로 빼던 해야할 듯 합니다
-    const projectDetailConfig: ProjectDetailConfig = {
-        'recruitEndAt': {
-            "label": "모집 마감",
-            "content": projectDetailContents.recruitEndAt,
-            "renderType": "text",
-        },
-        'progressPeriod':{
-            "label": "진행 기간",
-            "content": projectDetailContents.progressPeriod,
-            "renderType": "text",
-        },
-        'progressWay':{
-            "label": "진행 방식",
-            "content": projectDetailContents.progressWay,
-            "renderType": "text",
-        },
-        'contactWay':{
-            "label": "연락 방식",
-            "content": projectDetailContents.contactWay,
-            "renderType": "text",
-        },
-        'capacity':{
-            "label": "모집 인원",
-            "content": projectDetailContents.capacity,
-            "renderType": "text",
-        },
-        'positions':{
-            "label": "모집 포지션",
-            "content": projectDetailContents.positions,
-            "renderType": "positionChip",
-        },
-        'stacks':{
-            "label": "기술 스택",
-            "content": projectDetailContents.stacks,
-            "renderType": "stackIcon",
-        }
-    }
-
-    return <Container>
-        <Box><ProjectChip label={ProjectCategory} /></Box>
-        <ProjectDetailTable>
-            {Object.values(projectDetailConfig).map((value) => {
-                return <ProjectDetailRow {...value} />
-            })}
-        </ProjectDetailTable>
-    </Container>;
+  return (
+    <Container>
+      <Box>
+        <ProjectChip label={ProjectCategory} />
+      </Box>
+      <ProjectDetailTable>
+        {Object.values(projectDetailConfig).map((value) => {
+          return <ProjectDetailRow {...value} />;
+        })}
+      </ProjectDetailTable>
+    </Container>
+  );
 }
 
 const { color, boxShadow, mediaQueries } = DESIGN_TOKEN;
 
 const Container = styled.div`
-    height: fit-content;
+  height: fit-content;
 
-    padding: 8rem 3rem 3rem;
-    position: relative;
+  padding: 8rem 3rem 3rem;
+  position: relative;
 
-    background-color: ${color.white};
+  background-color: ${color.white};
 
-    border-radius: 1.5rem;
-    box-shadow: ${boxShadow.content};
+  border-radius: 1.5rem;
+  box-shadow: ${boxShadow.content};
 
-    ${mediaQueries.mobile}{
-        width: 32rem;
-    }
+  ${mediaQueries.mobile} {
+    width: 32rem;
+  }
 
-    ${mediaQueries.tablet}{
-        width: 50rem;
-    }
+  ${mediaQueries.tablet} {
+    width: 50rem;
+  }
 
-    ${mediaQueries.desktop}{
-        width: 35rem;
-    }
-`
+  ${mediaQueries.desktop} {
+    width: 35rem;
+  }
+`;
 
 const Box = styled.div`
-    position: absolute;
-    top: 3rem;
-    left: -0.2rem;
-    width: fit-content;
-    height: fit-content;
-`
+  position: absolute;
+  top: 3rem;
+  left: -0.2rem;
+  width: fit-content;
+  height: fit-content;
+`;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
@@ -1,12 +1,13 @@
-import ProjectChip, { ProjectType } from "@/components/commons/Chips/ProjectChip";
+import ProjectChip from "@/components/commons/Chips/ProjectChip";
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 import ProjectDetailTable from "./ProjectDetailTable";
 import { ProjectDetailConfig, ProjectDetailContentType } from "./types";
 import ProjectDetailRow from "./ProjectDetailRow";
+import { CategoryList } from "@/types/categoryTypes";
 
 interface ProjectDetailCardProps extends ProjectDetailContentType {
-  ProjectCategory: ProjectType;
+  ProjectCategory: CategoryList;
 }
 
 export default function ProjectDetailCard({ ProjectCategory, ...projectDetailContents }: ProjectDetailCardProps) {

--- a/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
@@ -36,7 +36,7 @@ export default function ProjectDetailCard({ ProjectCategory, ...projectDetailCon
     capacity: {
       label: "모집 인원",
       content: projectDetailContents.capacity,
-      renderType: "text",
+      renderType: "personNumber",
     },
     positions: {
       label: "모집 포지션",

--- a/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
@@ -1,21 +1,28 @@
 import { GetTypeFromObject } from "@/types/ObjectUtilTypes";
 
 // ProjectDetailCard내 Table에서 사용되는 Key
-export type ProjectDetailKey = "recruitEndAt" | "progressPeriod" | "progressWay" | "contactWay" | "capacity" |"positions" | "stacks";
+export type ProjectDetailKey =
+  | "recruitEndAt"
+  | "progressPeriod"
+  | "progressWay"
+  | "contactWay"
+  | "capacity"
+  | "positions"
+  | "stacks";
 
 // 구체적인 렌더링 방식
 export type RenderType = "text" | "positionChip" | "stackIcon";
 
 // ProjectDetailCard 내부에서 Table에게 전달할 Table Config
 export type ProjectDetailConfig = {
-    [key in ProjectDetailKey]: {
-        label: string;
-        content: string | string[];
-        renderType: RenderType;
-    }
-}
+  [key in ProjectDetailKey]: {
+    label: string;
+    content: string | string[];
+    renderType: RenderType;
+  };
+};
 
 // ProjectDetailTable에서 사용할 content는 Card 외부에서 받을 예정, 따라서 타입에서 필요한 정보만 추출
 export type ProjectDetailContentType = {
-    [key in ProjectDetailKey]: GetTypeFromObject<ProjectDetailConfig[key], "content">;
-}
+  [key in ProjectDetailKey]: GetTypeFromObject<ProjectDetailConfig[key], "content">;
+};

--- a/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
@@ -11,7 +11,7 @@ export type ProjectDetailKey =
   | "stacks";
 
 // 구체적인 렌더링 방식
-export type RenderType = "text" | "positionChip" | "stackIcon";
+export type RenderType = "text" | "positionChip" | "stackIcon" | "personNumber";
 
 // ProjectDetailCard 내부에서 Table에게 전달할 Table Config
 export type ProjectDetailConfig = {

--- a/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
@@ -12,12 +12,12 @@ export type ProjectDetailKey =
 
 // 구체적인 렌더링 방식
 export type RenderType = "text" | "positionChip" | "stackIcon" | "personNumber";
-
+export type ContentType = string | string[] | number;
 // ProjectDetailCard 내부에서 Table에게 전달할 Table Config
 export type ProjectDetailConfig = {
   [key in ProjectDetailKey]: {
     label: string;
-    content: string | string[];
+    content: ContentType;
     renderType: RenderType;
   };
 };

--- a/co-kkiri/src/types/ObjectUtilTypes.ts
+++ b/co-kkiri/src/types/ObjectUtilTypes.ts
@@ -10,4 +10,8 @@
     const a:GetTypeFromObject<A, "content"> = "hello"; // string | string[]
  * 
 */
-export type GetTypeFromObject<O, ObjectPropertyType extends PropertyKey> = O extends { [key in ObjectPropertyType]: infer ValueType } ? ValueType : never;
+export type GetTypeFromObject<O, ObjectPropertyType extends PropertyKey> = O extends {
+  [key in ObjectPropertyType]: infer ValueType;
+}
+  ? ValueType
+  : never;


### PR DESCRIPTION
### 📌요구사항
- [x] prettier 미적용 코드 수정
- [x] ProjectDetailCard personNum RenderType 추가
- [x] STUDY | PROJECT 부분 CategoryList로 변경

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
### 1.  prettier 미적용 코드 수정
- 죄송합니다
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/c8987db9-06fe-4eef-ad54-ddac0fcb0020)

### 2. ProjectDetailCard personNum RenderType 추가
- 먼저 RenderType을 추가했습니다
```tsx
export type RenderType = "text" | "positionChip" | "stackIcon" | "personNumber";
```
- 그리고 personNumber에 해당하는 renderType을 다시 짰습니다
```tsx
case "personNumber":
  return <p>{content}명</p>;
```
- 마지막으로 Render 결과를 추가해줍니다

### 3. STUDY | PROJECT 부분 CategoryList로 변경 및 $labelDesign prop 추가
```tsx
export type CategoryList = "STUDY" | "PROJECT";
```
- 윤경님이 만드신 type을 가져다 다른 곳에 반영했습니다
```tsx
type ProjectVariant = CategoryList;
...
const Container = styled(DefaultChip)<{ $labelDesign: ProjectVariant }>`
  ${({ $labelDesign }) => VARIANT_STYLE[$labelDesign]}
`;
```
- ProjectVariant도 CategoryList를 적용하면서, 새로운 prop이 필요해졌습니다
- 기존의 label은 util함수를 통해 `"스터디" | "프로젝트"` 를 불러오기 때문인데요.
- 이에 맞춰서 새로운 prop `$labelDesign`을 추가해줬습니다
```tsx
return <Container label={getTypeLabel(label)} $labelDesign={label} />;
```
- 이렇게 씁니다

### 📌스크린샷 / 테스트결과 (선택)
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/1c1b2124-02e1-40ca-ba3a-3ab39fca4fa0)


### 📌이슈 번호
Closes: #112 