### PR TITLE
Feat: 칩선택드롭다운 구현

### DIFF
--- a/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DefaultChip.tsx
@@ -79,8 +79,8 @@ const Container = styled.div<DefaultChipContainerStyleProps>`
   }
 
   & .icon {
-    max-width: 1.4rem;
-    max-height: 1.4rem;
+    width: 1.05rem;
+    height: 1.05rem;
     ${({ $isClickable }) => $isClickable && `cursor: pointer;`}
   }
 

--- a/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
@@ -11,6 +11,7 @@ interface DeleteStackChipProps {
 export default function DeleteStackChip({ label, onDelete }: DeleteStackChipProps) {
   const onClick = (e: MouseEvent<HTMLDivElement>) => {
     onDelete(label);
+    e.stopPropagation();
   };
 
   return <Container label={label} icon={ICONS.deleted} onIconClick={onClick} />;

--- a/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/DeleteStackChip.tsx
@@ -11,7 +11,6 @@ interface DeleteStackChipProps {
 export default function DeleteStackChip({ label, onDelete }: DeleteStackChipProps) {
   const onClick = (e: MouseEvent<HTMLDivElement>) => {
     onDelete(label);
-    e.stopPropagation();
   };
 
   return <Container label={label} icon={ICONS.deleted} onIconClick={onClick} />;

--- a/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
@@ -6,8 +6,13 @@ import { useRef, useState } from "react";
 import DeleteStackChipList from "../StackPopover/DeleteStackChipList";
 import { useResizeObserver } from "usehooks-ts";
 
-export default function MultiselectDropdown() {
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+interface MultiselectDropdownProps {
+  selectedOptions: string[];
+  limit?: number;
+  onSelectChange: (selectedOptions: string[]) => void;
+}
+
+export default function MultiselectDropdown({ selectedOptions, limit, onSelectChange }: MultiselectDropdownProps) {
   const { isOpen, openToggle, ref } = useOpenToggle();
   const dropButtonRef = useRef<HTMLButtonElement>(null);
   const { height } = useResizeObserver({
@@ -22,7 +27,7 @@ export default function MultiselectDropdown() {
           <DeleteStackChipList
             stacks={selectedOptions}
             onDeleteStack={(stack) => {
-              setSelectedOptions((prevStacks) => prevStacks.filter((prevStack) => prevStack !== stack));
+              onSelectChange(selectedOptions.filter((prevStack) => prevStack !== stack));
             }}
           />
         }
@@ -34,7 +39,8 @@ export default function MultiselectDropdown() {
       {isOpen && (
         <SelectLayout
           stacks={selectedOptions}
-          onStacksChange={(stacks) => setSelectedOptions([...stacks])}
+          limit={limit}
+          onStacksChange={(stacks) => onSelectChange([...stacks])}
           $top={height ? height : undefined}
         />
       )}

--- a/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
@@ -31,7 +31,11 @@ export default function MultiselectDropdown({ selectedOptions, limit, onSelectCh
             }}
           />
         }
-        onClick={openToggle}
+        onClick={(e) => {
+          if (e.target !== e.currentTarget) return;
+
+          openToggle();
+        }}
         $iconType="default"
         $isSelected={isOpen}
         dropButtonRef={dropButtonRef}

--- a/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
@@ -1,0 +1,55 @@
+import useOpenToggle from "@/hooks/useOpenToggle";
+import SquareDropButton from "./commons/SquareDropButton";
+import styled from "styled-components";
+import DefaultSelectLayout from "../StackPopover/SelectLayout";
+import { useRef, useState } from "react";
+import DeleteStackChipList from "../StackPopover/DeleteStackChipList";
+import { useResizeObserver } from "usehooks-ts";
+
+export default function MultiselectDropdown() {
+  const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+  const { isOpen, openToggle, ref } = useOpenToggle();
+  const dropButtonRef = useRef<HTMLButtonElement>(null);
+  const { height } = useResizeObserver({
+    ref: dropButtonRef,
+    box: "border-box",
+  });
+
+  return (
+    <Container ref={ref}>
+      <SquareDropButton
+        selectOption={
+          <DeleteStackChipList
+            stacks={selectedOptions}
+            onDeleteStack={(stack) => {
+              setSelectedOptions((prevStacks) => prevStacks.filter((prevStack) => prevStack !== stack));
+            }}
+          />
+        }
+        onClick={openToggle}
+        $iconType="default"
+        $isSelected={isOpen}
+        dropButtonRef={dropButtonRef}
+      />
+      {isOpen && (
+        <SelectLayout
+          stacks={selectedOptions}
+          onStacksChange={(stacks) => setSelectedOptions([...stacks])}
+          $top={height ? height : undefined}
+        />
+      )}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  position: relative;
+`;
+
+interface SelectLayoutProps {
+  $top: number | undefined;
+}
+
+const SelectLayout = styled(DefaultSelectLayout)<SelectLayoutProps>`
+  top: ${({ $top }) => ($top ? `${$top / 10 + 0.6}rem` : `5.4rem`)};
+`;

--- a/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
@@ -43,6 +43,7 @@ export default function MultiselectDropdown({ selectedOptions, limit, onSelectCh
       {isOpen && (
         <SelectLayout
           stacks={selectedOptions}
+          //TODO: limit 초과시 error 로직 짜야함
           limit={limit}
           onStacksChange={(stacks) => onSelectChange([...stacks])}
           $top={height ? height : undefined}

--- a/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/StackMultiselectDropdown.tsx
@@ -51,5 +51,6 @@ interface SelectLayoutProps {
 }
 
 const SelectLayout = styled(DefaultSelectLayout)<SelectLayoutProps>`
+  border-radius: 0.5rem;
   top: ${({ $top }) => ($top ? `${$top / 10 + 0.6}rem` : `5.4rem`)};
 `;

--- a/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
@@ -1,17 +1,20 @@
 import styled from "styled-components";
 import { ICONS } from "@/constants/icons";
 import DESIGN_TOKEN from "@/styles/tokens";
+import { MouseEvent, ReactNode, RefObject } from "react";
 
 interface DropdownButtonProps {
-  selectOption: string;
+  selectOption: ReactNode;
   onClick: () => void;
   $iconType: "date" | "default";
   $isSelected: boolean;
+  dropButtonRef?: RefObject<HTMLButtonElement>;
 }
 
 interface ContainerProps {
   $iconType: "date" | "default";
   $isSelected: boolean;
+  $isReactElement: boolean;
 }
 
 /**
@@ -23,15 +26,26 @@ interface ContainerProps {
  * @property {"date"|"default"} $iconType
  */
 
-export default function SquareDropButton({ selectOption, onClick, $iconType, $isSelected }: DropdownButtonProps) {
+export default function SquareDropButton({
+  selectOption,
+  onClick,
+  $iconType,
+  $isSelected,
+  dropButtonRef,
+}: DropdownButtonProps) {
   const iconSources = {
     date: { src: ICONS.calendar.src, alt: ICONS.calendar.alt },
     default: { src: ICONS.popover.src, alt: ICONS.popover.alt },
   };
 
   return (
-    <Container onClick={onClick} $iconType={$iconType} $isSelected={$isSelected}>
-      <div>{selectOption}</div>
+    <Container
+      onClick={onClick}
+      $iconType={$iconType}
+      $isSelected={$isSelected}
+      $isReactElement={typeof selectOption !== "string"}
+      ref={dropButtonRef}>
+      <Box>{selectOption}</Box>
       <img src={iconSources[$iconType].src} alt={iconSources[$iconType].alt} />
     </Container>
   );
@@ -44,10 +58,11 @@ const Container = styled.button<ContainerProps>`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0 2rem;
+  padding: ${({ $isReactElement }) => ($isReactElement ? `1.2rem 2rem` : `0 2rem`)};
   gap: 0.4rem;
   border-radius: 0.5rem;
-  height: 4.8rem;
+  height: ${({ $isReactElement }) => ($isReactElement ? `fit-content` : `4.8rem`)};
+  min-height: 4.8rem;
   ${typography.font16Medium}
   color : ${({ $isSelected }) => ($isSelected ? color.black[1] : color.black[3])};
   border: 0.1rem solid ${color.gray[2]};
@@ -55,4 +70,8 @@ const Container = styled.button<ContainerProps>`
   & img {
     width: 1.8rem;
   }
+`;
+
+const Box = styled.div`
+  flex-shrink: 1;
 `;

--- a/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { ICONS } from "@/constants/icons";
 import DESIGN_TOKEN from "@/styles/tokens";
-import { MouseEvent, ReactNode, RefObject } from "react";
+import { ReactNode, RefObject } from "react";
 
 interface DropdownButtonProps {
   selectOption: ReactNode;

--- a/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 import { ICONS } from "@/constants/icons";
 import DESIGN_TOKEN from "@/styles/tokens";
-import { ReactNode, RefObject } from "react";
+import { MouseEvent, ReactNode, RefObject } from "react";
 
 interface DropdownButtonProps {
   selectOption: ReactNode;
-  onClick: () => void;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   $iconType: "date" | "default";
   $isSelected: boolean;
   dropButtonRef?: RefObject<HTMLButtonElement>;

--- a/co-kkiri/src/components/commons/StackPopover/SelectLayout.tsx
+++ b/co-kkiri/src/components/commons/StackPopover/SelectLayout.tsx
@@ -9,19 +9,19 @@ import { StackPositionFilter, mappedFilter } from "./constants";
 import { getFilterKey } from "@/utils/ObjectUtils";
 
 interface SelectLayoutProps {
+  stacks: string[];
   onStacksChange: (selectedStacks: string[]) => void;
+  isDeletedChip?: boolean;
+  className?: string;
 }
 
-export default function SelectLayout({ onStacksChange }: SelectLayoutProps) {
+export default function SelectLayout({ stacks, onStacksChange, isDeletedChip, className }: SelectLayoutProps) {
   const [filter, setFilter] = useState<StackPositionFilter>("ALL");
-  const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
 
-  useEffect(() => {
-    onStacksChange(selectedStacks);
-  }, [selectedStacks, onStacksChange]);
+  useEffect(() => {}, [stacks, onStacksChange]);
 
   return (
-    <Container $isSelectedStacks={selectedStacks.length !== 0}>
+    <Container $isSelectedStacks={!!isDeletedChip && stacks.length !== 0} className={className}>
       <FilterList
         type="filter"
         currentFilter={mappedFilter[filter]}
@@ -32,26 +32,26 @@ export default function SelectLayout({ onStacksChange }: SelectLayoutProps) {
         }}
       />
       <StackChipList
-        selectedStacks={selectedStacks}
+        selectedStacks={stacks}
         filter={filter}
         onStackChipClick={(stack) => {
-          if (selectedStacks.includes(stack)) {
-            setSelectedStacks((prevStacks) => prevStacks.filter((prevStack) => prevStack !== stack));
+          if (stacks.includes(stack)) {
+            onStacksChange(stacks.filter((prevStack) => prevStack !== stack));
           } else {
-            setSelectedStacks((prevStacks) => [...prevStacks, stack]);
+            onStacksChange([...stacks, stack]);
           }
         }}
       />
       <ResetButton
         onReset={() => {
-          setSelectedStacks([]);
+          onStacksChange([]);
         }}
       />
-      {selectedStacks.length !== 0 && (
+      {!!isDeletedChip && stacks.length !== 0 && (
         <DeleteStackChipList
-          stacks={selectedStacks}
+          stacks={stacks}
           onDeleteStack={(stack) => {
-            setSelectedStacks((prevStacks) => prevStacks.filter((prevStack) => prevStack !== stack));
+            onStacksChange(stacks.filter((prevStack) => prevStack !== stack));
           }}
         />
       )}

--- a/co-kkiri/src/components/commons/StackPopover/SelectLayout.tsx
+++ b/co-kkiri/src/components/commons/StackPopover/SelectLayout.tsx
@@ -12,12 +12,12 @@ interface SelectLayoutProps {
   stacks: string[];
   onStacksChange: (selectedStacks: string[]) => void;
   isDeletedChip?: boolean;
+  limit?: number;
   className?: string;
 }
 
-export default function SelectLayout({ stacks, onStacksChange, isDeletedChip, className }: SelectLayoutProps) {
+export default function SelectLayout({ stacks, onStacksChange, isDeletedChip, limit, className }: SelectLayoutProps) {
   const [filter, setFilter] = useState<StackPositionFilter>("ALL");
-
   useEffect(() => {}, [stacks, onStacksChange]);
 
   return (
@@ -38,6 +38,9 @@ export default function SelectLayout({ stacks, onStacksChange, isDeletedChip, cl
           if (stacks.includes(stack)) {
             onStacksChange(stacks.filter((prevStack) => prevStack !== stack));
           } else {
+            //limit 초과해서 담을 수는 없음
+            if (limit && stacks.length >= limit) return;
+
             onStacksChange([...stacks, stack]);
           }
         }}


### PR DESCRIPTION
### 📌요구사항
- [x] 칩선택드롭다운 구현

### 요청
- 이름이 조금 더럽네요, 조금 더 좋은 컴포넌트 이름 있다면 추천받습니다

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
### SquareDropButton 변경사항
```tsx
interface DropdownButtonProps {
  selectOption: ReactNode;
  //...
  dropButtonRef?: RefObject<HTMLButtonElement>;
}
```
**1. SquareDropbutton에 text만이 아닌 다른 ReactNode도 받게되었습니다**
```tsx
<SquareDropButton
  selectOption={
    <DeleteStackChipList/>
  }
  //...
/>
```
- 덕분에 아래처럼 보여줄 수 있어요

![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/ed86e07c-d4ab-4023-b3c1-903920b71621)
</br>

**2. 살짝의 CSS 속성 변동이 생겼습니다**
- 들어온 selectOption이 string인지 아닌지(아니라면 ReactNode라고 우선 간주)판단합니다
- ReactNode라면 Styled-Component의 `$isReactElement`가 **true**가 됩니다
- 이에따라 SqaureDropButton의 height가 달라집니다
```css
  padding: ${({ $isReactElement }) => ($isReactElement ? `1.2rem 2rem` : `0 2rem`)};
  height: ${({ $isReactElement }) => ($isReactElement ? `fit-content` : `4.8rem`)};
  min-height: 4.8rem;
```
- min-height는 내부에 값이 없을 때 DropDown이 쭈그러드는 문제가 생길 수 있어서, 이를 보완하려고 넣었습니다
- fit-content는 node가 Dropdown의 원래 높이인 4.8rem을 넘을 수 있기 때문에 높이가 유동적으로 바뀔 수 있도록`fit-content`로 두었습니다.
</br>
------------------------------------------------------------------------
</br>

### StackMultiselectDropdown 구현사항

- Stack을 고를 수 있는 Dropdown입니다
- SelectLayout의 재활용이 있었습니다
- useOpenToggle을 이용해서 열림 상태 관리가 가능합니다
</br>

**1. DropdownButton 내에 DeleteStackChip이 추가됩니다**
![selectChipdropdown-mobile](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/14f4f627-eb19-4de6-b685-d5590de04010)

- Chip List가 Dropdown 너비를 넘어가면 아래로 내려갑니다
</br>

**2. 누른 타겟이 DropButton인지 내부 요소인지 판단합니다**
```tsx
onClick={(e) => {
  if (e.target !== e.currentTarget) return;

  openToggle();
}}
```
- DropButton의 경우 기본적으로 누르면 창이 열고 닫히는 이벤트가 발생합니다.
- 하지만 Chip도 x버튼을 누르면 삭제되는 event가 발생하죠
- **문젠 DropButton안에 Chip이 있어서 이벤트 버블링이 일어난다는 겁니다.**

=> 따라서 이를 체크하는 로직을 통해 칩이 삭제되면서 창이 닫히는 문제를 해결했습니다.
</br>

**3. limit로 선택 가능 개수를 제한할 수 있습니다**
![test](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/c5d0be3b-b0d1-469d-95f8-cb8fabd46e29)

- limit에 값을 전달하면, 초과해서 선택할 수 없습니다
```tsx
<StackChipList
  selectedStacks={stacks}
  filter={filter}
  onStackChipClick={(stack) => {
    if (stacks.includes(stack)) {
      onStacksChange(stacks.filter((prevStack) => prevStack !== stack));
    } else {
      //limit 초과해서 담을 수는 없음
      if (limit && stacks.length >= limit) return;

      onStacksChange([...stacks, stack]);
    }
  }}
/>
```
</br>

**4. DropButton의 높이가 달라져도 list가 높이를 감지하고 재배치됩니다**
![test](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/46c4707c-309f-436c-8f5a-3a3fc8812b1b)

- 캡쳐할 때 Chip색상이 안보이는데, 멀쩡합니다.. 캡쳐프로그램 잘못입니다

```tsx
export default function MultiselectDropdown(){
  //...
  const dropButtonRef = useRef<HTMLButtonElement>(null);
  const { height } = useResizeObserver({
    ref: dropButtonRef,
    box: "border-box",
  });

  return (
    <Container ref={ref}>
      <SquareDropButton
        //...
        dropButtonRef={dropButtonRef}
      />
      {isOpen && (
        <SelectLayout
          //...
          $top={height ? height : undefined}
        />
      )}
    </Container>
  );
}

const SelectLayout = styled(DefaultSelectLayout)<SelectLayoutProps>`
  //...
  top: ${({ $top }) => ($top ? `${$top / 10 + 0.6}rem` : `5.4rem`)};
`;
```
- `useResizeObserver`에서 DropButton의 height 값을 추적합니다
- 이에 따라 height값 변경시 SelectLayout의 top 값도 재배치됩니다 (간격 0.6rem)


### 📌스크린샷 / 테스트결과 (선택)
- 상기 참조

### 📌이슈 번호
Closes: #81 