### PR TITLE
Refactor: api 함수 더블 체크 및 주석 추가

### DIFF
--- a/co-kkiri/src/lib/api/axios.ts
+++ b/co-kkiri/src/lib/api/axios.ts
@@ -32,7 +32,7 @@ export async function apiRequest<T, U>(
     const response: AxiosResponse<T> = await axiosInstance(request);
     return { data: response.data, errorMessage: null };
   } catch (error) {
-    if (axios.isAxiosError(error)) {
+    if (axios.isAxiosError(error) && error.response) {
       const errorMessage = error.response?.data?.message;
       return { data: null, errorMessage };
     } else {

--- a/co-kkiri/src/lib/api/comment/index.ts
+++ b/co-kkiri/src/lib/api/comment/index.ts
@@ -2,14 +2,18 @@ import { commentAddress } from "../address";
 import { ApiRequestResponse, apiRequest } from "../axios";
 import { CommentApiResponseDto, CreateCommentApiRequestDto, ModifyCommentApiRequestDto } from "./type";
 
+/** 댓글 목록 가져오기 */
 export const getCommentList = (postId: number): Promise<ApiRequestResponse<CommentApiResponseDto>> =>
   apiRequest("get", commentAddress.list(postId));
 
+/** 댓글 달기 */
 export const createComment = (postId: number, data: CreateCommentApiRequestDto) =>
   apiRequest("post", commentAddress.write(postId), data);
 
+/** 댓글 수정 */
 export const editComment = (postId: number, commentId: number, data: ModifyCommentApiRequestDto) =>
   apiRequest("patch", commentAddress.commentId(postId, commentId), data);
 
+/** 댓글 삭제 */
 export const deleteComment = (postId: number, commentId: number) =>
   apiRequest("delete", commentAddress.commentId(postId, commentId));

--- a/co-kkiri/src/lib/api/home/index.ts
+++ b/co-kkiri/src/lib/api/home/index.ts
@@ -2,4 +2,5 @@ import { homeAddress } from "../address";
 import { ApiRequestResponse, apiRequest } from "../axios";
 import { HomeApiResponseDto } from "./type";
 
+/** home 페이지 카드 리스트 가져오기 */
 export const getHomeCardList = (): Promise<ApiRequestResponse<HomeApiResponseDto>> => apiRequest("get", homeAddress);

--- a/co-kkiri/src/lib/api/member/index.ts
+++ b/co-kkiri/src/lib/api/member/index.ts
@@ -6,9 +6,14 @@ import {
   SearchedMemberProfileApiResponseDto,
 } from "./type";
 
+/** 유저 프로필 가져오기 */
 export const getMemberProfile = (memberId: number): Promise<ApiRequestResponse<MemberProfileApiResponseDto>> =>
   apiRequest("get", memberAddress.memberId(memberId));
 
+/** 유저 프로필 검색
+ *
+ *@param {SearchedMemberProfileApiRequestDto}  qs  쿼리스트링을 객체로 받습니다.
+ */
 export const getSearchedMemberProfile = (
   qs: SearchedMemberProfileApiRequestDto,
 ): Promise<ApiRequestResponse<SearchedMemberProfileApiResponseDto>> =>

--- a/co-kkiri/src/lib/api/myPage/index.ts
+++ b/co-kkiri/src/lib/api/myPage/index.ts
@@ -8,18 +8,24 @@ import {
   VisibleProfileStatusApiRequestDto,
 } from "./type";
 
+/** 마이페이지 유저 정보 가져오기 */
 export const getUserInfo = (): Promise<ApiRequestResponse<UserInfoApiResponseDto>> =>
   apiRequest("get", myPageAddress.userInfo);
 
+/** 마이페이지 유저 정보 수정하기 */
 export const editUserInfo = (data: UserInfoEditApiRequestDto) => apiRequest("patch", myPageAddress.userInfo, data);
 
+/** 초대된 팀 목록 가져오기 */
 export const getInvitedTeamList = (): Promise<ApiRequestResponse<InvitedTeamListApiResponseDto>> =>
   apiRequest("get", myPageAddress.inviteList);
 
+/** 스크랩 목록 가져오기 */
 export const getScrapList = (): Promise<ApiRequestResponse<MyScrapApiResponseDto>> =>
   apiRequest("get", myPageAddress.scrapList);
 
+/** 프로필 공개 여부 수정하기 */
 export const editVisibleProfileStatus = (data: VisibleProfileStatusApiRequestDto) =>
   apiRequest("patch", myPageAddress.visibleProfile, data);
 
+/** 회원 탈퇴하기 */
 export const deleteUser = () => apiRequest("delete", myPageAddress.myPage);

--- a/co-kkiri/src/lib/api/myPost/index.ts
+++ b/co-kkiri/src/lib/api/myPost/index.ts
@@ -7,23 +7,30 @@ import {
   RecruitedListApiResponseDto,
 } from "./type";
 
+/** 내가 신청한 스터디 목록 가져오기 */
 export const getApplyList = (): Promise<ApiRequestResponse<MyAppliedListApiResponseDto>> =>
   apiRequest("get", myPostAddress.applyList);
 
+/** 내가 모집한 스터디 목록 가져오기 */
 export const getRecruitList = (): Promise<ApiRequestResponse<RecruitedListApiResponseDto>> =>
   apiRequest("get", myPostAddress.recruitList);
 
+/** 내가 진행중인 스터디 목록 가져오기 */
 export const getOnGoingList = (): Promise<ApiRequestResponse<OnGoingListApiResponseDto>> =>
   apiRequest("get", myPostAddress.onGoingList);
 
+/** 내가 완료한 스터디 목록 가져오기 */
 export const getCompletedList = (): Promise<ApiRequestResponse<CompletedListApiResponseDto>> =>
   apiRequest("get", myPostAddress.completedList);
 
+/** 진행중인 스터디 완료하기 */
 // data 추가해야 함
 export const completeOnGoing = () => apiRequest("patch", myPostAddress.onGoingComplete);
 
+/** 피어리뷰 작성하기 */
 //data 추가해야 함
 export const createReview = () => apiRequest("post", myPostAddress.review);
 
+/** 피어리뷰 목록 가져오기 */
 // Promise 추가해야 함
 export const getReviewInfo = () => apiRequest("get", myPostAddress.reviewInfo);

--- a/co-kkiri/src/lib/api/post/index.ts
+++ b/co-kkiri/src/lib/api/post/index.ts
@@ -13,48 +13,53 @@ import {
   StudyManagementApiResponseDto,
 } from "./type";
 
-/** 스터디 모집하기 */
-export const createPost = (data: RecruitApiRequestDto) => apiRequest("post", postAddress.recruit, data);
-
-/**스터디 리스트 가져오기
+/**
+ * studyList 페이지용 스터디 리스트 가져오기
  *
  *@param {ListApiRequestDto}  qs  쿼리스트링을 객체로 받습니다.
  */
 export const getPostList = (qs: ListApiRequestDto): Promise<ApiRequestResponse<ListApiResponseDto>> =>
   apiRequest("get", postAddress.list, null, qs);
 
-/** 스카우트 목록 리스트 백엔드 확인 요망*/
-export const getPostListForScout = (): Promise<ApiRequestResponse<ScoutListApiResponseDto>> =>
-  apiRequest("get", postAddress.scout);
-
-/** 스터디 글 가져오기*/
+/** 스터디 상세 보기*/
 export const getPostDetail = (postId: number): Promise<ApiRequestResponse<PostDetailApiResponseDto>> =>
   apiRequest("get", postAddress.postId(postId));
+
+/** 스터디 글 작성하기 */
+export const createPost = (data: RecruitApiRequestDto) => apiRequest("post", postAddress.recruit, data);
+
+/** 스터디 글 수정하기 */
+export const modifyPost = (postId: number, data: RecruitApiRequestDto) =>
+  apiRequest("patch", postAddress.modify(postId), data);
 
 /** 스터디 글 삭제하기 */
 export const deletePost = (postId: number) => apiRequest("delete", postAddress.postId(postId));
 
-/** 스터디 글 지원하기 */
+/** 스터디 지원하기 */
 export const applyPost = (postId: number, data: ApplyPostApiRequestDto) =>
   apiRequest("post", postAddress.apply(postId), data);
 
-/** 스터디 글 지원하기 */
+/** 지원한 유저 목록 가져오기
+ *
+ *@param {number} postId
+ *@param {AppliedMemberListApiRequestDto}  qs  쿼리스트링을 객체로 받습니다.
+ */
 export const getAppliedMemberList = (
   postId: number,
   qs: AppliedMemberListApiRequestDto,
 ): Promise<ApiRequestResponse<AppliedMemberListApiResponseDto>> =>
   apiRequest("get", postAddress.apply(postId), null, qs);
 
-/** 스터디 글 수정하기 */
-export const modifyPost = (postId: number, data: RecruitApiRequestDto) =>
-  apiRequest("patch", postAddress.modify(postId), data);
+/** 스터디 초대를 위한 내가 만든 스터디 리스트 */
+export const getPostListForInvite = (): Promise<ApiRequestResponse<ScoutListApiResponseDto>> =>
+  apiRequest("get", postAddress.scout);
+
+/** 스터디 초대하기 */
+export const inviteMember = (data: InviteMemberRequestDto) => apiRequest("post", postAddress.invite, data);
 
 /** 스터디 프로젝트 정보  */
 export const getStudyManagement = (postId: number): Promise<ApiRequestResponse<StudyManagementApiResponseDto>> =>
   apiRequest("get", postAddress.management(postId));
-
-/** 스터디 멤버 초대하기 */
-export const inviteMember = (data: InviteMemberRequestDto) => apiRequest("post", postAddress.invite, data);
 
 //아래 함수들은 api 문서 수정되면 한번에 반영해놓겠습니다.
 
@@ -67,5 +72,5 @@ export const recruitEnd = (postId: number) => apiRequest("patch", postAddress.re
 /** 스터디 모집 완료하기 */
 export const recruitComplete = (postId: number) => apiRequest("patch", postAddress.recruitComplete(postId));
 
-//** 이미지 url 가져오기 */
+/** 이미지 url 가져오기 */
 export const getImageUploadUrl = () => apiRequest("post", imageAddress);

--- a/co-kkiri/src/lib/api/teamMember/index.ts
+++ b/co-kkiri/src/lib/api/teamMember/index.ts
@@ -2,12 +2,16 @@ import { teamMemberAddress } from "../address";
 import { apiRequest } from "../axios";
 import { TeamMemberApiRequestDto } from "./type";
 
+/** 현재 팀원 목록 가져오기 */
 // data 추가해야 함
 export const getTeamMember = (postId: number, qs: TeamMemberApiRequestDto) =>
   apiRequest("get", teamMemberAddress.teamMember(postId), null, qs);
 
+/** 신청 수락하기 */
 export const acceptMember = (teamMemberId: number) => apiRequest("patch", teamMemberAddress.accept(teamMemberId));
 
+/** 신청 거절하기 */
 export const rejectMember = (teamMemberId: number) => apiRequest("patch", teamMemberAddress.reject(teamMemberId));
 
+/** 현재 팀원 삭제하기 */
 export const deleteTeamMember = (teamMemberId: number) => apiRequest("delete", teamMemberAddress.out(teamMemberId));


### PR DESCRIPTION
### 📌요구사항
- [x] api 함수 더블 체크
- [x] api 함수에 주석 추가

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- 함수는 api url의 엔드포인트 별로 정리했습니다.
  - 단, post 엔드포인트가 너무 많아서 아래 두 경우 폴더를 분리했습니다.
    - `/post/[postId]/comment`, `/post/[postId]/[commentId]`의 경우 post가 아닌 comment 폴더에 있습니다.
    - `/post/team-member`, 의 경우 post가 아닌 teamMember 폴더에 있습니다.

- apiRequest 함수는 4개의 파라미터(method, url, data, params)를 받습니다.
```js
export async function apiRequest<T, U>(
  method: HttpMethod,
  url: string,
  data?: U,
  params?: Record<string, unknown>,
  config?: AxiosRequestConfig,
): Promise<ApiRequestResponse<T>> {
  try {
    const request: AxiosRequestConfig = {
      url,
      method,
      data,
      params,
      ...config,
    };
    const response: AxiosResponse<T> = await axiosInstance(request);
    return { data: response.data, errorMessage: null };
  } catch (error) {
    if (axios.isAxiosError(error) && error.response) {
      const errorMessage = error.response?.data?.message;
      return { data: null, errorMessage };
    } else {
      console.error(`${method} Error : `, error);
      throw error;
    }
  }
}

```
- params는 url의 query string으로 아래와 같이 객체에 담아서 보내면 됩니다.
  ```js
    const qs = {
    page: 1,
    limit: 10,
    category: 'news'
  };
  ```

- 더블 체크 했으나 사용할 때 수정해야 하는 상황이 발생할 수 있습니다.

### 📌스크린샷 / 테스트결과 (선택)


### 📌이슈 번호
