### PR TITLE
Feat: 구글 Oauth 기능 구현

### DIFF
--- a/co-kkiri/src/PageRouter.tsx
+++ b/co-kkiri/src/PageRouter.tsx
@@ -10,9 +10,10 @@ import Scout from "@/pages/Scout";
 import MyPage from "@/pages/MyPage";
 import Manage from "@/pages/Manage";
 import MyStudy from "@/pages/MyStudy";
-import Profile from "@/pages/Profile";
 import { ROUTER_PATH } from "@/lib/path";
 import Navigation from "./layouts/Navigation";
+import GoogleAuth from "./pages/Auth/GoogleAuth";
+import AuthListener from "./components/commons/AuthListener";
 
 const {
   HOME_PATH,
@@ -25,12 +26,13 @@ const {
   MY_PAGE,
   MY_STUDY,
   MANAGE,
-  PROFILE,
+  GOOGLE_REDIRECT,
 } = ROUTER_PATH;
 
 const PageRouter = () => {
   return (
     <Router>
+      <AuthListener />
       <Routes>
         <Route path="/" element={<Navigation />}>
           <Route path={HOME_PATH} element={<Home />} />
@@ -44,9 +46,9 @@ const PageRouter = () => {
           <Route path={MY_STUDY} element={<MyStudy />} />
           //TODO: Manage 페이지에 id값을 넘겨줘야함
           <Route path={MANAGE} element={<Manage id={1} />} />
-          <Route path={PROFILE} element={<Profile />} />
           <Route path="*" element={<NotFound />} />
         </Route>
+        <Route path={GOOGLE_REDIRECT} element={<GoogleAuth />} />
       </Routes>
     </Router>
   );

--- a/co-kkiri/src/components/commons/AuthListener.ts
+++ b/co-kkiri/src/components/commons/AuthListener.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { googleLogin } from "@/lib/api/auth";
+import useAuthModalToggleStore from "@/stores/authModalToggle";
+
+const AuthListener = () => {
+  const setIsAuthModalOpen = useAuthModalToggleStore((state) => state.setIsAuthModalOpen);
+
+  const getAccessToken = async (code: string) => {
+    const response = await googleLogin(code);
+    // console.log(response); 리스폰스 확인용
+  };
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data && event.data.type === "OAuthSuccess") {
+        getAccessToken(event.data.code);
+        setIsAuthModalOpen(false);
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [setIsAuthModalOpen]);
+
+  return null;
+};
+
+export default AuthListener;
+function googleLogins() {
+  throw new Error("Function not implemented.");
+}

--- a/co-kkiri/src/components/commons/Gnb/index.tsx
+++ b/co-kkiri/src/components/commons/Gnb/index.tsx
@@ -8,6 +8,7 @@ import UserInfo from "../UserInfo";
 import UserPopover from "../UserPopover";
 import AuthModal from "@/components/modals/AuthModal";
 import useOpenToggle from "@/hooks/useOpenToggle";
+import useAuthModalToggleStore from "@/stores/authModalToggle";
 
 interface GnbProps {
   user?: {
@@ -21,11 +22,8 @@ export default function Gnb({ user, onSideBarClick }: GnbProps) {
   const { HOME_PATH, RECRUIT_PATH } = ROUTER_PATH;
   const { ref, isOpen: isPopoverOpen, openToggle: togglePopover } = useOpenToggle();
 
-  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
-
-  const handleAuthModalOpen = () => {
-    setIsAuthModalOpen(!isAuthModalOpen);
-  };
+  const isAuthModalOpen = useAuthModalToggleStore((state) => state.isAuthModalOpen);
+  const toggleAuthModal = useAuthModalToggleStore((state) => state.toggleAuthModal);
 
   const handlePopoverOpen = () => {
     togglePopover();
@@ -49,11 +47,11 @@ export default function Gnb({ user, onSideBarClick }: GnbProps) {
           {user ? (
             <UserInfo user={user} onClick={handlePopoverOpen} />
           ) : (
-            <S.SignButton onClick={handleAuthModalOpen}>로그인/회원가입</S.SignButton>
+            <S.SignButton onClick={toggleAuthModal}>로그인/회원가입</S.SignButton>
           )}
         </S.RightGroupWrapper>
       </S.Box>
-      {isAuthModalOpen && <AuthModal onClick={handleAuthModalOpen} onClose={handleAuthModalOpen} />}
+      {isAuthModalOpen && <AuthModal onClick={toggleAuthModal} onClose={toggleAuthModal} />}
       {user && <UserPopover isPopoverOpen={isPopoverOpen} handleSelectOption={handlePopoverOpen} />}
     </S.Container>
   );

--- a/co-kkiri/src/components/modals/AuthModal.tsx
+++ b/co-kkiri/src/components/modals/AuthModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 import ModalLayout from "./ModalLayout";
@@ -5,6 +6,7 @@ import { IMAGES } from "@/constants/images";
 import { Link } from "react-router-dom";
 import { ROUTER_PATH } from "@/lib/path";
 import { authAddress } from "@/lib/api/address";
+import openLoginPopup from "@/utils/openLoginPopup";
 
 interface AuthModalProps {
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -22,10 +24,8 @@ export default function AuthModal({ onClick, onClose }: AuthModalProps) {
         </Link>
         <span>로그인 / 회원가입</span>
         <LoginButtonBox>
-          <LoginButton $padding={0.9}>
-            <Link to={authAddress.google.login}>
-              <img src={IMAGES.googleLogo.src} alt={IMAGES.googleLogo.alt} />
-            </Link>
+          <LoginButton $padding={0.9} onClick={() => openLoginPopup(authAddress.google.login)}>
+            <img src={IMAGES.googleLogo.src} alt={IMAGES.googleLogo.alt} />
           </LoginButton>
           <LoginButton $padding={1.3}>
             <img src={IMAGES.githubLogo.src} alt={IMAGES.githubLogo.alt} />

--- a/co-kkiri/src/lib/api/address.ts
+++ b/co-kkiri/src/lib/api/address.ts
@@ -7,7 +7,7 @@ export const authAddress = {
     //get
     login: `${BASE_URL}/auth/google/login`,
     //post
-    redirect: "/auth/google/redirect",
+    redirect: (code: string) => `/auth/google/redirect?code=${code}`,
   },
 };
 

--- a/co-kkiri/src/lib/api/auth/index.ts
+++ b/co-kkiri/src/lib/api/auth/index.ts
@@ -1,0 +1,6 @@
+import { authAddress } from "../address";
+import { apiRequest } from "../axios";
+
+const { google } = authAddress;
+
+export const googleLogin = (code: string) => apiRequest("post", google.redirect(code));

--- a/co-kkiri/src/lib/api/axios.ts
+++ b/co-kkiri/src/lib/api/axios.ts
@@ -7,7 +7,7 @@ export interface ApiRequestResponse<T> {
   errorMessage: string | null;
 }
 
-export const BASE_URL = "";
+export const BASE_URL = "http://52.79.214.183:8080";
 
 export const axiosInstance = axios.create({
   baseURL: BASE_URL,

--- a/co-kkiri/src/lib/path.ts
+++ b/co-kkiri/src/lib/path.ts
@@ -9,5 +9,5 @@ export const ROUTER_PATH = {
   MY_PAGE: "/mypage",
   MY_STUDY: "/mystudy",
   MANAGE: "/mystudy/:id",
-  PROFILE: "/profile",
+  GOOGLE_REDIRECT: "/auth/google/redirect",
 };

--- a/co-kkiri/src/pages/Auth/GoogleAuth.tsx
+++ b/co-kkiri/src/pages/Auth/GoogleAuth.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export default function GoogleAuth() {
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get("code");
+
+  useEffect(() => {
+    const message = { type: "OAuthSuccess", code: code };
+    // localhost는 추후 변경해야함
+    window.opener.postMessage(message, "http://localhost");
+    window.close();
+  });
+
+  return null;
+}

--- a/co-kkiri/src/pages/Profile.tsx
+++ b/co-kkiri/src/pages/Profile.tsx
@@ -1,5 +1,0 @@
-export default function Profile() {
-  return (
-    <div>Profile</div>
-  )
-}

--- a/co-kkiri/src/stores/authModalToggle.ts
+++ b/co-kkiri/src/stores/authModalToggle.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface AuthModalState {
+  isAuthModalOpen: boolean;
+  setIsAuthModalOpen: (state: boolean) => void;
+  toggleAuthModal: () => void;
+}
+
+const useAuthModalToggleStore = create<AuthModalState>((set) => ({
+  isAuthModalOpen: false,
+  setIsAuthModalOpen: (state) => set({ isAuthModalOpen: state }),
+  toggleAuthModal: () => set((state) => ({ isAuthModalOpen: !state.isAuthModalOpen })),
+}));
+
+export default useAuthModalToggleStore;

--- a/co-kkiri/src/utils/openLoginPopup.ts
+++ b/co-kkiri/src/utils/openLoginPopup.ts
@@ -1,0 +1,15 @@
+const openLoginPopup = (address: string) => {
+  const loginUrl = address;
+  const windowName = "googleLoginPopup";
+  const width = 500;
+  const height = 600;
+
+  const left = window.screen.width / 2 - width / 2;
+  const top = window.screen.height / 2 - height / 2;
+
+  const options = `width=${width},height=${height},top=${top},left=${left}`;
+
+  window.open(loginUrl, windowName, options);
+};
+
+export default openLoginPopup;


### PR DESCRIPTION
### 📌요구사항
- [x] 구글 Oauth 기능 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
#### 전반적인 로직
1. (modal) Gnb의 AuthModal에서 구글 버튼 클릭
2. (popup) 구글 로그인 팝업창이 뜸
3. (popup) 유저가 구글 로그인을 수행함 -> 로그인 성공
4. (popup) redirect 페이지인 GoogleAuth 페이지로 이동 후 AuthListener 컴포넌트에 `code` 정보 전달 후 팝업 닫음
5. (page) AuthListener 컴포넌트에서 `code` 정보를 받으면 post 리퀘스트 보내고 모달 닫음
6. post  리퀘스트의 리스폰스 헤더에 Set-Cookie 정보가 옴
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/d3716274-7833-47e1-94ed-8988783997a2)
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/a446f2d0-442e-4a57-8923-47b3db595679)

#### 변경사항
- Gnb의 isAuthModalOpen state를 zustand에서 관리하는 걸로 변경했습니다.
- 현재 axios 파일의 `BASE_URL`이 `http://52.79.214.183:8080`입니다. 추후 변경해야 합니다.

#### 추후 해야할 일
- redirect 요청 두번 보내짐 
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/d3b44ffb-c31c-46ed-b8f2-04a007e81b5d)
- 유저 닉네임 및 프로필 이미지 받아서 Gnb에 표시해야 함
- signin과 signup 구분은 어떻게 하지?

### 📌스크린샷 / 테스트결과 (선택)
- 구글 Oauth 과정

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/ee2589cf-e9bb-420b-9072-17c359ced37f

### 📌이슈 번호
close #128 