### PR TITLE
Feat: 유저인포 레이아웃 구현

### DIFF
--- a/co-kkiri/src/components/commons/Chips/PositionChip.tsx
+++ b/co-kkiri/src/components/commons/Chips/PositionChip.tsx
@@ -2,8 +2,9 @@ import DefaultChip from "./DefaultChip";
 
 interface PositionChipProps {
   label: string;
+  className?: string;
 }
 
-export default function PositionChip({ label }: PositionChipProps) {
-  return <DefaultChip label={label} />;
+export default function PositionChip({ label, className }: PositionChipProps) {
+  return <DefaultChip label={label} className={className} />;
 }

--- a/co-kkiri/src/components/commons/CircularProgressBar.tsx
+++ b/co-kkiri/src/components/commons/CircularProgressBar.tsx
@@ -1,50 +1,89 @@
+import { HexColor } from "@/types/styledUtilTypes";
+import { isValidHexColor } from "@/utils/styleUtils";
 import styled from "styled-components";
 
 interface CircularProgressBarProps {
   percentage: number;
+  size: number;
+  strokeWidth: number;
+  backgroundColor?: HexColor;
+  topColor?: HexColor;
+  bottomColor?: HexColor;
+  animationDuration?: number;
+  className?: string;
 }
 
-export default function CircularProgressBar({ percentage }: CircularProgressBarProps) {
+export default function CircularProgressBar({
+  percentage,
+  size,
+  strokeWidth,
+  backgroundColor,
+  topColor,
+  bottomColor,
+  animationDuration,
+  className,
+}: CircularProgressBarProps) {
   return (
-    <div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="130px" height="130px">
+    <Container className={className} $strokeWidth={strokeWidth}>
+      <svg xmlns="http://www.w3.org/2000/svg" width={`${size / 10}rem`} height={`${size / 10}rem`}>
         <defs>
           <linearGradient id="linear-gradient" gradientUnits="userSpaceOnUse">
-            <stop stopColor="#29C4BA" />
-            <stop offset="1" stopColor="#BCEBE8" />
+            <stop offset="0" stopColor={topColor && isValidHexColor(topColor) ? topColor : "#29C4BA"} />
+            <stop offset="1" stopColor={bottomColor && isValidHexColor(bottomColor) ? bottomColor : "#BCEBE8"} />
           </linearGradient>
         </defs>
-        <Background cx={65} cy={65} r={60} strokeWidth={10} fill="none" stroke="#f1f8f7" />
+        <Background
+          cx={`${size / 20}rem`}
+          cy={`${size / 20}rem`}
+          r={`${(size - strokeWidth) / 20}rem`}
+          strokeWidth={`${strokeWidth / 10}rem`}
+          fill="none"
+          stroke={backgroundColor && isValidHexColor(backgroundColor) ? backgroundColor : "#f1f8f7"}
+        />
         {percentage > 0 && (
           <Progress
             aria-label="progress-bar"
-            cx={65}
-            cy={65}
-            r={60}
+            cx={`${size / 20}rem`}
+            cy={`${size / 20}rem`}
+            r={`${(size - strokeWidth) / 20}rem`}
             fill="none"
             stroke="url(#linear-gradient)"
             strokeLinecap="round"
-            strokeWidth={10}
+            strokeWidth={`${strokeWidth / 10}rem`}
             pathLength={100}
             transform="rotate(-90 65 65)"
             strokeDasharray={100}
             $percentage={100 - percentage > 0 ? 100 - percentage : 0}
+            $animationDuration={animationDuration}
           />
         )}
       </svg>
-    </div>
+    </Container>
   );
 }
+
+interface ContainerProps {
+  $strokeWidth: number;
+}
+const Container = styled.div<ContainerProps>`
+  ${({ $strokeWidth }) => `
+    width: calc(100% + ${$strokeWidth / 10}rem);
+    height: calc(100% + ${$strokeWidth / 10}rem);
+`}
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 const Background = styled.circle``;
 
 interface ProgressProps {
   $percentage: number;
+  $animationDuration?: number;
 }
 
 const Progress = styled.circle<ProgressProps>`
-  background-color: beige;
-
   @keyframes progress {
     from {
       stroke-dashoffset: 100;
@@ -54,5 +93,6 @@ const Progress = styled.circle<ProgressProps>`
     }
   }
 
-  animation: progress 1s ease-out forwards 1;
+  animation: progress ${({ $animationDuration }) => ($animationDuration ? `${$animationDuration}s` : `0.8s`)} ease-out
+    forwards 1;
 `;

--- a/co-kkiri/src/components/commons/CircularProgressBar.tsx
+++ b/co-kkiri/src/components/commons/CircularProgressBar.tsx
@@ -1,5 +1,6 @@
 import { HexColor } from "@/types/styledUtilTypes";
 import { isValidHexColor } from "@/utils/styleUtils";
+import { useId } from "react";
 import styled from "styled-components";
 
 interface CircularProgressBarProps {
@@ -23,16 +24,19 @@ export default function CircularProgressBar({
   animationDuration,
   className,
 }: CircularProgressBarProps) {
+  const id = useId();
+
   return (
     <Container className={className} $strokeWidth={strokeWidth}>
       <svg xmlns="http://www.w3.org/2000/svg" width={`${size / 10}rem`} height={`${size / 10}rem`}>
         <defs>
-          <linearGradient id="linear-gradient" gradientUnits="userSpaceOnUse">
+          <linearGradient id={id} gradientUnits="userSpaceOnUse">
             <stop offset="0" stopColor={topColor && isValidHexColor(topColor) ? topColor : "#29C4BA"} />
             <stop offset="1" stopColor={bottomColor && isValidHexColor(bottomColor) ? bottomColor : "#BCEBE8"} />
           </linearGradient>
         </defs>
-        <Background
+        <circle
+          className="background-circle"
           cx={`${size / 20}rem`}
           cy={`${size / 20}rem`}
           r={`${(size - strokeWidth) / 20}rem`}
@@ -46,12 +50,12 @@ export default function CircularProgressBar({
             cx={`${size / 20}rem`}
             cy={`${size / 20}rem`}
             r={`${(size - strokeWidth) / 20}rem`}
-            fill="none"
-            stroke="url(#linear-gradient)"
-            strokeLinecap="round"
             strokeWidth={`${strokeWidth / 10}rem`}
+            fill="none"
+            stroke={`url(#${id})`}
+            strokeLinecap="round"
             pathLength={100}
-            transform="rotate(-90 65 65)"
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
             strokeDasharray={100}
             $percentage={100 - percentage > 0 ? 100 - percentage : 0}
             $animationDuration={animationDuration}
@@ -75,8 +79,6 @@ const Container = styled.div<ContainerProps>`
   justify-content: center;
   align-items: center;
 `;
-
-const Background = styled.circle``;
 
 interface ProgressProps {
   $percentage: number;

--- a/co-kkiri/src/components/commons/CircularProgressBar.tsx
+++ b/co-kkiri/src/components/commons/CircularProgressBar.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+
+interface CircularProgressBarProps {
+  percentage: number;
+}
+
+export default function CircularProgressBar({ percentage }: CircularProgressBarProps) {
+  return (
+    <div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="130px" height="130px">
+        <defs>
+          <linearGradient id="linear-gradient" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#29C4BA" />
+            <stop offset="1" stopColor="#BCEBE8" />
+          </linearGradient>
+        </defs>
+        <Background cx={65} cy={65} r={60} strokeWidth={10} fill="none" stroke="#f1f8f7" />
+        {percentage > 0 && (
+          <Progress
+            aria-label="progress-bar"
+            cx={65}
+            cy={65}
+            r={60}
+            fill="none"
+            stroke="url(#linear-gradient)"
+            strokeLinecap="round"
+            strokeWidth={10}
+            pathLength={100}
+            transform="rotate(-90 65 65)"
+            strokeDasharray={100}
+            $percentage={100 - percentage > 0 ? 100 - percentage : 0}
+          />
+        )}
+      </svg>
+    </div>
+  );
+}
+
+const Background = styled.circle``;
+
+interface ProgressProps {
+  $percentage: number;
+}
+
+const Progress = styled.circle<ProgressProps>`
+  background-color: beige;
+
+  @keyframes progress {
+    from {
+      stroke-dashoffset: 100;
+    }
+    to {
+      stroke-dashoffset: ${({ $percentage }) => $percentage};
+    }
+  }
+
+  animation: progress 1s ease-out forwards 1;
+`;

--- a/co-kkiri/src/components/commons/Stacks.tsx
+++ b/co-kkiri/src/components/commons/Stacks.tsx
@@ -32,6 +32,8 @@ export default function Stacks({ stacks, variant = "profile" }: StacksProps) {
         limit = isSidebarOpenNarrow ? desktopNarrow : desktopWide;
       }
       setDisplayPositions(stacks.slice(0, limit));
+    } else if (variant === "profile") {
+      setDisplayPositions(stacks.slice(0, 3));
     }
   }, [variant, stacks, windowWidth, isSidebarOpenNarrow]);
 

--- a/co-kkiri/src/components/commons/UserProfileCard/UserProfileCardLayout.tsx
+++ b/co-kkiri/src/components/commons/UserProfileCard/UserProfileCardLayout.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import CircularProgressBar from "../CircularProgressBar";
 import DefaultUserImage from "@/components/modals/EditUserProfileModal/UserImage";
-import PositionChip from "../Chips/PositionChip";
+import DetailedPositionChip from "../Chips/PositionChip";
 import DESIGN_TOKEN from "@/styles/tokens";
 import Stacks from "../Stacks";
 
@@ -11,6 +11,7 @@ interface UserProfileCardProps {
   position: string;
   career: number;
   stacks: string[];
+  score: number;
 }
 
 export default function UserProfileCardLayout({
@@ -19,11 +20,12 @@ export default function UserProfileCardLayout({
   position,
   career,
   stacks,
+  score,
 }: UserProfileCardProps) {
   return (
     <Container>
       <ProgressBox>
-        <CircularProgressBar size={130} strokeWidth={8} percentage={50} animationDuration={1} />
+        <CircularProgressBar size={130} strokeWidth={8} percentage={score} animationDuration={1} />
         <UserImage profileImgUrl={profileImgUrl} onSelect={() => {}} />
       </ProgressBox>
       <PositionChip label={position} />
@@ -40,7 +42,6 @@ const Container = styled.article`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.2rem;
 `;
 
 const ProgressBox = styled.div`
@@ -48,6 +49,8 @@ const ProgressBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  margin-bottom: 1.2rem;
 `;
 
 const UserImage = styled(DefaultUserImage)`
@@ -57,11 +60,18 @@ const UserImage = styled(DefaultUserImage)`
   transform: translate(-50%, -50%);
 `;
 
+const PositionChip = styled(DetailedPositionChip)`
+  margin-bottom: 1.2rem;
+`;
+
 const Nickname = styled.p`
   ${typography.font16Bold}
+  margin-bottom: 0.4rem;
 `;
 
 const Career = styled.p`
   ${typography.font12Semibold}
   color: ${color.primary[1]};
+
+  margin-bottom: 2rem;
 `;

--- a/co-kkiri/src/components/commons/UserProfileCard/UserProfileCardLayout.tsx
+++ b/co-kkiri/src/components/commons/UserProfileCard/UserProfileCardLayout.tsx
@@ -1,0 +1,67 @@
+import styled from "styled-components";
+import CircularProgressBar from "../CircularProgressBar";
+import DefaultUserImage from "@/components/modals/EditUserProfileModal/UserImage";
+import PositionChip from "../Chips/PositionChip";
+import DESIGN_TOKEN from "@/styles/tokens";
+import Stacks from "../Stacks";
+
+interface UserProfileCardProps {
+  profileImgUrl?: string;
+  nickname: string;
+  position: string;
+  career: number;
+  stacks: string[];
+}
+
+export default function UserProfileCardLayout({
+  profileImgUrl,
+  nickname,
+  position,
+  career,
+  stacks,
+}: UserProfileCardProps) {
+  return (
+    <Container>
+      <ProgressBox>
+        <CircularProgressBar size={130} strokeWidth={8} percentage={50} animationDuration={1} />
+        <UserImage profileImgUrl={profileImgUrl} onSelect={() => {}} />
+      </ProgressBox>
+      <PositionChip label={position} />
+      <Nickname>{nickname}</Nickname>
+      <Career>경력 {career}년차</Career>
+      <Stacks stacks={stacks} />
+    </Container>
+  );
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const Container = styled.article`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.2rem;
+`;
+
+const ProgressBox = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const UserImage = styled(DefaultUserImage)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const Nickname = styled.p`
+  ${typography.font16Bold}
+`;
+
+const Career = styled.p`
+  ${typography.font12Semibold}
+  color: ${color.primary[1]};
+`;

--- a/co-kkiri/src/components/commons/UserProfileCard/index.tsx
+++ b/co-kkiri/src/components/commons/UserProfileCard/index.tsx
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import UserProfileCardLayout from "./UserProfileCardLayout";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+interface UserProfileCardProps {
+  profileImgUrl?: string;
+  nickname: string;
+  position: string;
+  career: number;
+  stacks: string[];
+  score: number;
+}
+
+export default function UserProfileCard(props: UserProfileCardProps) {
+  return (
+    <Container>
+      <UserProfileCardLayout {...props} />
+    </Container>
+  );
+}
+
+const { boxShadow } = DESIGN_TOKEN;
+
+const Container = styled.div`
+  width: 100%;
+  min-width: fit-content;
+
+  padding: 3rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+
+  border-radius: 2rem;
+  box-shadow: ${boxShadow.content};
+`;

--- a/co-kkiri/src/components/modals/EditUserProfileModal/UserImage.tsx
+++ b/co-kkiri/src/components/modals/EditUserProfileModal/UserImage.tsx
@@ -6,7 +6,7 @@ import DefaultFileSelector from "./FileSelector";
 interface EditUserImageProps {
   profileImgUrl?: string;
   isEditable?: boolean;
-  onSelect: (file: File | FileList) => void;
+  onSelect?: (file: File | FileList) => void;
   className?: string;
 }
 
@@ -14,7 +14,7 @@ export default function UserImage({ profileImgUrl, isEditable, onSelect, classNa
   return (
     <Container className={className}>
       <ProfileImg src={profileImgUrl ? profileImgUrl : IMAGES.profileImg.src} alt={IMAGES.profileImg.alt} />
-      {isEditable && (
+      {isEditable && onSelect && (
         <FileSelector
           name="profile"
           icon={ICONS.camera}
@@ -37,8 +37,6 @@ const Container = styled.div`
   position: relative;
   justify-self: center;
   align-self: center;
-
-
 `;
 
 const ProfileImg = styled.img`

--- a/co-kkiri/src/types/styledUtilTypes.ts
+++ b/co-kkiri/src/types/styledUtilTypes.ts
@@ -3,3 +3,5 @@ import { RuleSet } from "styled-components";
 export type VariantStyle<Variant extends string> = {
   [key in Variant]: RuleSet<object>;
 };
+
+export type HexColor = `#${string}`;

--- a/co-kkiri/src/utils/styleUtils.ts
+++ b/co-kkiri/src/utils/styleUtils.ts
@@ -1,0 +1,3 @@
+export function isValidHexColor(color: string): boolean {
+  return /^#[0-9A-F]{6}$/i.test(color);
+}


### PR DESCRIPTION
### 📌요구사항
- [x] 프로그레스 바 구현
- [x] 유저인포 레이아웃 구현
- [ ] 유저인포 모달 구현 

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- 모달을 구현하지 못했습니다 아직, 그런데 다른 분들이 쓰일 일이 꽤 있을 것 같아 우선 급한대로 layout만 내보냅니다.

<h2>Progress Bar</h2>

![scout-1 0](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/107f35ac-e067-4320-a323-0e2c03de390d)

- 시각적으로 진행 상태를 나타내기 위해 사용
- svg 및 animation를 활용해서 동적 디자인 및 애니메이션이 가능

<h3>Prop</h3>

**1. percentage** 
- 진행률을 나타내는 숫자
- 0에서 100 사이의 값

**2. size**
- 프로그레스 바의 전체 크기
- px 단위로 입력
 
**3. strokeWidth**
- 프로그레스 바의 선 두께
- px 단위로 입력

**4. backgroundColor**
- 프로그레스 바의 배경 원형 색상
- 유효한 HEX 색상 코드를 받으며, 기본값은 #f1f8f7

**5. topColor**
- 그라데이션의 시작 색상
- 유효한 HEX 색상 코드를 받으며, 기본값은 #29C4BA

**6. bottomColor**
- 그라데이션의 끝 색상
- 유효한 HEX 색상 코드를 받으며, 기본값은 #BCEBE8

**7. animationDuration**
- 애니메이션의 지속 시간을 초 단위로 설정
- 설정하지 않을 경우 기본값은 0.8초

<h2>UserProfileCardLayout 및 UserProfileCard</h2>

- 기존에 만들어 놓은 컴포넌트를 조합한 것밖에 없습니다
- 필요에 따라 Layout 혹은 Card 쓰시면 될 것 같아요
- Card는 Layout에 테두리만 적용한 겁니다. (참고로 width 100%)

### 📌스크린샷 / 테스트결과 (선택)
![card](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/b9b79cfc-4271-49ba-be7a-2a1bb4243c05)


### 📌이슈 번호
Closes: #114
