### PR TITLE
Fix: CircularProgressBar Animation 오류 해결

### DIFF
--- a/co-kkiri/src/components/commons/CircularProgressBar.tsx
+++ b/co-kkiri/src/components/commons/CircularProgressBar.tsx
@@ -86,7 +86,7 @@ interface ProgressProps {
 }
 
 const Progress = styled.circle<ProgressProps>`
-  @keyframes progress {
+  @keyframes ${({ $percentage }) => `progress-${$percentage}`} {
     from {
       stroke-dashoffset: 100;
     }
@@ -95,6 +95,6 @@ const Progress = styled.circle<ProgressProps>`
     }
   }
 
-  animation: progress ${({ $animationDuration }) => ($animationDuration ? `${$animationDuration}s` : `0.8s`)} ease-out
+  animation: ${({ $percentage }) => `progress-${$percentage}`} ${({ $animationDuration }) => ($animationDuration ? `${$animationDuration}s` : `0.8s`)} ease-out
     forwards 1;
 `;


### PR DESCRIPTION
### 📌요구사항
- [x] 서로 다른 score에 서로 다른 progress를 보여주도록 버그 수정

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
<h3>문제</h3>

모든 Circular Progress가 같은 animation keyframe을 공유하고 있습니다.
그러다보니, 모든 CircularProgress가 score prop의 값과는 관련 없이, 같은 animation to 값을 가지고 있습니다.
그래서 score이 모두 달라도 같은 값으로 보이고 있습니다.

<h3>상황</h3>

스카우트 페이지에서 많은 CircularProgress 컴포넌트를 한번에 불러올 때 발생

<h3>해결 과정</h3>

<h4>기존</h4>

```tsx
const Progress = styled.circle<ProgressProps>`
  @keyframes progress {
    from {
      stroke-dashoffset: 100;
    }
    to {
      stroke-dashoffset: ${({ $percentage }) => $percentage};
    }
  }

  animation: progress ${({ $animationDuration }) => ($animationDuration ? `${$animationDuration}s` : `0.8s`)} ease-out
    forwards 1;
`;
```

- animation이 모두 같은 이름으로 공유되고 있음
- 이에 따라 충돌이 발생하여, 한 페이지 내 모든 CircularProgressBar의 진행도가 동일해 보임

<h4>현재</h4>

```tsx
const Progress = styled.circle<ProgressProps>`
  @keyframes ${({ $percentage }) => `progress-${$percentage}`} {
    from {
      stroke-dashoffset: 100;
    }
    to {
      stroke-dashoffset: ${({ $percentage }) => $percentage};
    }
  }

  animation: ${({ $percentage }) => `progress-${$percentage}`} ${({ $animationDuration }) => ($animationDuration ? `${$animationDuration}s` : `0.8s`)} ease-out
    forwards 1;
`;
```

- animation에 고유한 이름을 부여하여, 다른 percentage 간의 충돌 없앰

### 📌스크린샷 / 테스트결과 (선택)
<h4>문제</h4>

![progress-bar-animation-bug](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/297d7d4e-3e84-46d1-86f6-e6ec94b6aece)


<h4>현재</h4>

![progress-bar-animation-bug-sol](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/2af0f39c-9a9c-497c-a779-9fb57388292f)

### 📌이슈 번호
Closes: #152 