### PR TITLE
Feat: 모집글 작성 수정 페이지 api연동 제외

### DIFF
--- a/co-kkiri/src/components/commons/DropDowns/DeadlineDropdown/DeadlineDropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/DeadlineDropdown/DeadlineDropdown.tsx
@@ -8,7 +8,7 @@ import useOpenToggle from "@/hooks/useOpenToggle";
 import SquareDropButton from "../commons/SquareDropButton";
 import { Calendar } from "./ui/calendar";
 interface DeadlineDropdownProps {
-  placeholder: string;
+  placeholder: string | null;
   selectedOption: string;
   onSelect: (option: string) => void;
 }

--- a/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
@@ -4,8 +4,8 @@ import DropMenu from "./commons/DropMenu";
 import styled from "styled-components";
 
 interface DropdownProps {
-  placeholder?: string;
-  selectedOption?: string;
+  placeholder: string;
+  selectedOption?: string | null;
   options: string[];
   onSelect: (option: string) => void;
   dropdownRef?: React.RefCallback<HTMLButtonElement>;

--- a/co-kkiri/src/components/commons/ReactQuill/index.tsx
+++ b/co-kkiri/src/components/commons/ReactQuill/index.tsx
@@ -21,9 +21,9 @@ const formats = [
 ];
 
 export default function QuillEditor({
-  setSelectedOption,
+  setSelectedOptions,
 }: {
-  setSelectedOption: React.Dispatch<React.SetStateAction<RecruitApiRequestDto>>;
+  setSelectedOptions: React.Dispatch<React.SetStateAction<RecruitApiRequestDto>>;
 }) {
   const modules = useMemo(() => {
     return {
@@ -34,14 +34,14 @@ export default function QuillEditor({
   }, []);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedOption((prevOptions) => ({
+    setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       title: e.target.value,
     }));
   };
 
   const handleContentChange = (content: string) => {
-    setSelectedOption((prevOptions) => ({
+    setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       content: content,
     }));

--- a/co-kkiri/src/components/commons/ReactQuill/index.tsx
+++ b/co-kkiri/src/components/commons/ReactQuill/index.tsx
@@ -4,7 +4,7 @@ import "react-quill/dist/quill.snow.css";
 import CustomToolbar from "./CustomToolbar";
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
-import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
+import { RecruitApiRequestDto } from "@/lib/api/post/type";
 
 const formats = [
   "header",
@@ -23,7 +23,7 @@ const formats = [
 export default function QuillEditor({
   setSelectedOption,
 }: {
-  setSelectedOption: React.Dispatch<React.SetStateAction<RecruitmentRequest>>;
+  setSelectedOption: React.Dispatch<React.SetStateAction<RecruitApiRequestDto>>;
 }) {
   const modules = useMemo(() => {
     return {

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/LinkInput.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/LinkInput.tsx
@@ -9,12 +9,12 @@ interface LinkInputProps {
 
 export default function LinkInput({ selectedOption, onChange }: LinkInputProps) {
   const { recruitment } = DROPDOWN_INFO;
-  const optionIndex = recruitment.contactWay.options?.indexOf(selectedOption);
-  const value = recruitment.contactWay.placeholder[optionIndex];
+  const optionIndex = recruitment.contactWay.options.indexOf(selectedOption);
+  const value = selectedOption ? String(recruitment.contactWay.placeholder[optionIndex]) : "";
 
   return (
     <Container>
-      {selectedOption !== "기타" ? <Input placeholder={value} onChange={(e) => onChange(e.target.value)} /> : null}
+      {selectedOption !== "기타" && <Input placeholder={value} onChange={(e) => onChange(e.target.value)} />}
     </Container>
   );
 }

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/RecruitLayout.styled.ts
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/RecruitLayout.styled.ts
@@ -24,12 +24,38 @@ export const Container = styled.form`
   }
 `;
 
+export const SelectContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 77.4rem;
+  gap: 4rem;
+
+  & p {
+    ${typography.font12Medium}
+    color: ${color.red};
+  }
+
+  & h1 {
+    border-bottom: 0.1rem solid ${color.gray[2]};
+    padding-bottom: 2rem;
+  }
+
+  ${mediaQueries.tablet} {
+    width: 46.2rem;
+  }
+
+  ${mediaQueries.mobile} {
+    width: 32rem;
+  }
+`;
+
 export const GirdContainer = styled.div`
   & h3 {
     display: flex;
 
     & span {
       color: ${color.red};
+      margin-left: 0.2rem;
     }
   }
 
@@ -74,10 +100,6 @@ export const RadioButtonBox = styled.div`
     display: flex;
     gap: 3rem;
   }
-
-  & p {
-    margin-top: -1.2rem;
-  }
 `;
 
 export const RadioButtonWarper = styled.div`
@@ -102,16 +124,24 @@ export const SelectBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+  height: 10.1rem;
+
+  & p {
+    position: relative;
+    top: -0.4rem;
+  }
 `;
 
 export const SelectChipBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  height: 9.5rem;
 
   & h3 {
     & span {
       color: ${color.red};
+      margin-left: 0.2rem;
     }
   }
 
@@ -122,7 +152,7 @@ export const SelectChipBox = styled.div`
   }
 
   & p {
-    margin-top: -0.95rem;
+    margin-top: -1.2rem;
   }
 `;
 
@@ -141,28 +171,4 @@ export const SubmitButtonBox = styled.div`
   grid-template-columns: repeat(2, 15.6rem);
   gap: 1.2rem;
   justify-content: end;
-`;
-
-export const SelectContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  width: 77.4rem;
-  gap: 4rem;
-
-  & p {
-    color: ${color.red};
-  }
-
-  & h1 {
-    border-bottom: 0.1rem solid ${color.gray[2]};
-    padding-bottom: 2rem;
-  }
-
-  ${mediaQueries.tablet} {
-    width: 46.2rem;
-  }
-
-  ${mediaQueries.mobile} {
-    width: 32rem;
-  }
 `;

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -80,7 +80,7 @@ export default function RecruitmentRequestLayout({
     control,
     formState: { errors },
   } = useForm();
-
+  console.log(selectedOptions);
   return (
     <S.SelectContainer onSubmit={handleSubmit((selectedOptions: RecruitApiRequestDto) => onSubmit(selectedOptions))}>
       <h1>스터디/프로젝트 정보 입력</h1>
@@ -113,7 +113,7 @@ export default function RecruitmentRequestLayout({
         </S.RadioButtonBox>
         <S.SelectBox>
           <h3>
-            모집 마감 기간 <span>*</span>
+            모집 마감 기간<span>*</span>
           </h3>
           <Controller
             name="recruitEndAt"
@@ -163,7 +163,7 @@ export default function RecruitmentRequestLayout({
         </S.SelectBox>
         <S.SelectBox>
           <h3>
-            진행 방식 <span>*</span>
+            진행 방식<span>*</span>
           </h3>
           <Controller
             name="progressWay"

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -7,16 +7,16 @@ import SelectPositionChipList from "@/components/commons/SelectPositionChipList"
 import * as S from "./RecruitLayout.styled";
 import { DROPDOWN_INFO } from "@/constants/dropDown";
 import { useState } from "react";
-import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
+import { RecruitApiRequestDto } from "@/lib/api/post/type";
 import { format } from "date-fns";
 import LinkInput from "./LinkInput";
 import Button from "../Button";
 import { useForm, Controller } from "react-hook-form";
 
 interface RecruitmentRequestLayoutProps {
-  onSubmit: (data: RecruitmentRequest) => void;
+  onSubmit: (data: RecruitApiRequestDto) => void;
   buttonText: string;
-  defaultOption?: RecruitmentRequest;
+  defaultOption?: RecruitApiRequestDto;
 }
 
 export default function RecruitmentRequestLayout({
@@ -28,11 +28,11 @@ export default function RecruitmentRequestLayout({
     recruitment: { capacity, progressPeriod, progressWay, contactWay },
   } = DROPDOWN_INFO;
 
-  const initialOption: RecruitmentRequest = {
+  const initialOption: RecruitApiRequestDto = {
     type: "STUDY",
     recruitEndAt: "",
     progressPeriod: "",
-    capacity: undefined,
+    capacity: null,
     contactWay: "",
     progressWay: "",
     stacks: [],
@@ -42,7 +42,8 @@ export default function RecruitmentRequestLayout({
     link: "",
   };
 
-  const [selectedOption, setSelectedOption] = useState<RecruitmentRequest>(
+  //초기값으로 기본값옵션을 전달해주고있으면 기본값옵션으로 없으면 원시값옵션으로
+  const [selectedOption, setSelectedOption] = useState<RecruitApiRequestDto>(
     defaultOption ? defaultOption : initialOption,
   );
 

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -31,15 +31,15 @@ export default function RecruitmentRequestLayout({
   const initialOption: RecruitApiRequestDto = {
     type: "STUDY",
     recruitEndAt: "",
-    progressPeriod: "",
+    progressPeriod: null,
     capacity: null,
-    contactWay: "",
-    progressWay: "",
-    stacks: [],
+    contactWay: null,
+    progressWay: null,
+    stacks: null,
     positions: [],
-    title: "",
-    content: "",
-    link: "",
+    title: null,
+    content: null,
+    link: null,
   };
 
   //초기값으로 기본값옵션을 전달해주고있으면 기본값옵션으로 없으면 원시값옵션으로
@@ -209,7 +209,7 @@ export default function RecruitmentRequestLayout({
           {selectedOption.contactWay !== "기타" && (
             <>
               <Controller
-                name={selectedOption.contactWay}
+                name={selectedOption.contactWay || ""}
                 control={control}
                 rules={{
                   pattern: {
@@ -225,7 +225,7 @@ export default function RecruitmentRequestLayout({
                 }}
                 render={({ field }) => (
                   <LinkInput
-                    selectedOption={selectedOption.contactWay}
+                    selectedOption={selectedOption.contactWay || ""}
                     onChange={(link) => {
                       setSelectedOption((prevOption) => ({ ...prevOption, link: link }));
                       field.onChange(link);
@@ -233,17 +233,19 @@ export default function RecruitmentRequestLayout({
                   />
                 )}
               />
-              {errors[selectedOption.contactWay] && <p>{String(errors[selectedOption.contactWay]?.message)}</p>}
+              {selectedOption.contactWay !== null && errors[selectedOption.contactWay] && (
+                <p>{String(errors[selectedOption.contactWay]?.message)}</p>
+              )}
             </>
           )}
         </S.SelectBox>
       </S.GirdContainer>
       <S.SelectChipBox>
         <h3>기술 스택</h3>
-        <MultiselectDropdown
+        {/* <MultiselectDropdown
           selectedOptions={selectedOption.stacks}
           onSelectChange={(stack) => handleSelectStack(stack)}
-        />
+        /> */}
       </S.SelectChipBox>
       <S.SelectChipBox>
         <h3>

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -12,6 +12,7 @@ import { format } from "date-fns";
 import LinkInput from "./LinkInput";
 import Button from "../Button";
 import { useForm, Controller } from "react-hook-form";
+import { CategoryList } from "@/types/categoryTypes";
 
 interface RecruitmentRequestLayoutProps {
   onSubmit: (data: RecruitApiRequestDto) => void;
@@ -52,7 +53,7 @@ export default function RecruitmentRequestLayout({
     return options[index];
   };
 
-  const handleSelectType = (type: "STUDY" | "PROJECT"): void => {
+  const handleSelectType = (type: CategoryList): void => {
     setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       type: type,

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -32,7 +32,7 @@ export default function RecruitmentRequestLayout({
     type: "STUDY",
     recruitEndAt: "",
     progressPeriod: null,
-    capacity: null,
+    capacity: 10,
     contactWay: null,
     progressWay: null,
     stacks: null,
@@ -43,7 +43,7 @@ export default function RecruitmentRequestLayout({
   };
 
   //초기값으로 기본값옵션을 전달해주고있으면 기본값옵션으로 없으면 원시값옵션으로
-  const [selectedOption, setSelectedOption] = useState<RecruitApiRequestDto>(
+  const [selectedOptions, setSelectedOptions] = useState<RecruitApiRequestDto>(
     defaultOption ? defaultOption : initialOption,
   );
 
@@ -53,21 +53,21 @@ export default function RecruitmentRequestLayout({
   };
 
   const handleSelectType = (type: "STUDY" | "PROJECT"): void => {
-    setSelectedOption((prevOptions) => ({
+    setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       type: type,
     }));
   };
 
   const handleSelectStack = (stacks: string[]): void => {
-    setSelectedOption((prevOptions) => ({
+    setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       stacks: stacks,
     }));
   };
 
   const handleSelectPosition = (position: string): void => {
-    setSelectedOption((prevOptions) => ({
+    setSelectedOptions((prevOptions) => ({
       ...prevOptions,
       positions: prevOptions.positions.includes(position)
         ? prevOptions.positions.filter((prevPosition) => prevPosition !== position)
@@ -76,12 +76,13 @@ export default function RecruitmentRequestLayout({
   };
 
   const {
+    handleSubmit,
     control,
     formState: { errors },
   } = useForm();
 
   return (
-    <S.SelectContainer>
+    <S.SelectContainer onSubmit={handleSubmit((selectedOptions: RecruitApiRequestDto) => onSubmit(selectedOptions))}>
       <h1>스터디/프로젝트 정보 입력</h1>
       <S.GirdContainer>
         <S.RadioButtonBox>
@@ -89,38 +90,26 @@ export default function RecruitmentRequestLayout({
             모집 구분 <span>*</span>
           </h3>
           <span>
-            <Controller
-              name="type"
-              control={control}
-              rules={{ required: true }}
-              render={({ field }) => (
-                <>
-                  <S.RadioButtonWarper>
-                    <RadioButton
-                      defaultChecked
-                      value="STUDY"
-                      onClick={() => {
-                        handleSelectType("STUDY");
-                        field.onChange("STUDY");
-                      }}
-                    />
-                    <span>스터디</span>
-                  </S.RadioButtonWarper>
-                  <S.RadioButtonWarper>
-                    <RadioButton
-                      value="PROJECT"
-                      onClick={() => {
-                        handleSelectType("PROJECT");
-                        field.onChange("PROJECT");
-                      }}
-                    />
-                    <span>프로젝트</span>
-                  </S.RadioButtonWarper>
-                </>
-              )}
-            />
+            <S.RadioButtonWarper>
+              <RadioButton
+                defaultChecked
+                value="STUDY"
+                onClick={() => {
+                  handleSelectType("STUDY");
+                }}
+              />
+              <span>스터디</span>
+            </S.RadioButtonWarper>
+            <S.RadioButtonWarper>
+              <RadioButton
+                value="PROJECT"
+                onClick={() => {
+                  handleSelectType("PROJECT");
+                }}
+              />
+              <span>프로젝트</span>
+            </S.RadioButtonWarper>
           </span>
-          {errors.type && <p>모집 구분을 선택해주세요.</p>}
         </S.RadioButtonBox>
         <S.SelectBox>
           <h3>
@@ -134,9 +123,9 @@ export default function RecruitmentRequestLayout({
               <>
                 <DeadlineDropdown
                   placeholder="모집 마감 기간"
-                  selectedOption={selectedOption.recruitEndAt}
+                  selectedOption={selectedOptions.recruitEndAt}
                   onSelect={(option) => {
-                    setSelectedOption((prevOptions) => ({
+                    setSelectedOptions((prevOptions) => ({
                       ...prevOptions,
                       recruitEndAt: option,
                     }));
@@ -153,9 +142,9 @@ export default function RecruitmentRequestLayout({
           <Dropdown
             placeholder={progressPeriod.defaultValue}
             options={progressPeriod.options}
-            selectedOption={selectedOption.progressPeriod}
+            selectedOption={selectedOptions.progressPeriod}
             onSelect={(option) => {
-              setSelectedOption((prevOption) => ({ ...prevOption, progressPeriod: option }));
+              setSelectedOptions((prevOption) => ({ ...prevOption, progressPeriod: option }));
             }}
           />
         </S.SelectBox>
@@ -164,11 +153,11 @@ export default function RecruitmentRequestLayout({
           <Dropdown
             placeholder={capacity.defaultValue}
             options={capacity.options}
-            selectedOption={findOptionByValue(capacity.values, capacity.options, selectedOption.capacity)}
+            selectedOption={findOptionByValue(capacity.values, capacity.options, selectedOptions.capacity)}
             onSelect={(option) => {
               const optionIndex = capacity.options.indexOf(option);
               const value = capacity.values[optionIndex];
-              setSelectedOption((prevOption) => ({ ...prevOption, capacity: value }));
+              setSelectedOptions((prevOption) => ({ ...prevOption, capacity: value }));
             }}
           />
         </S.SelectBox>
@@ -185,9 +174,9 @@ export default function RecruitmentRequestLayout({
                 <Dropdown
                   placeholder={progressWay.defaultValue}
                   options={progressWay.options}
-                  selectedOption={selectedOption?.progressWay}
+                  selectedOption={selectedOptions.progressWay}
                   onSelect={(option) => {
-                    setSelectedOption((prevOption) => ({ ...prevOption, progressWay: option }));
+                    setSelectedOptions((prevOption) => ({ ...prevOption, progressWay: option }));
                     field.onChange(option);
                   }}
                 />
@@ -201,40 +190,40 @@ export default function RecruitmentRequestLayout({
           <Dropdown
             placeholder={contactWay.defaultValue}
             options={contactWay.options}
-            selectedOption={selectedOption?.contactWay}
+            selectedOption={selectedOptions.contactWay}
             onSelect={(option) => {
-              setSelectedOption((prevOption) => ({ ...prevOption, contactWay: option }));
+              setSelectedOptions((prevOption) => ({ ...prevOption, contactWay: option }));
             }}
           />
-          {selectedOption.contactWay !== "기타" && (
+          {selectedOptions.contactWay !== "기타" && (
             <>
               <Controller
-                name={selectedOption.contactWay || ""}
+                name={selectedOptions.contactWay || ""}
                 control={control}
                 rules={{
                   pattern: {
                     value:
-                      selectedOption.contactWay === "이메일"
+                      selectedOptions.contactWay === "이메일"
                         ? /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i
                         : /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,})\/?([\w/#.-]*)*(\?[\w=&.-]*)?(#[\w-]*)?$/,
                     message:
-                      selectedOption.contactWay === "이메일"
+                      selectedOptions.contactWay === "이메일"
                         ? "올바른 이메일 형식이 아닙니다."
                         : "올바른 url 형식이 아닙니다",
                   },
                 }}
                 render={({ field }) => (
                   <LinkInput
-                    selectedOption={selectedOption.contactWay || ""}
+                    selectedOption={selectedOptions.contactWay || ""}
                     onChange={(link) => {
-                      setSelectedOption((prevOption) => ({ ...prevOption, link: link }));
+                      setSelectedOptions((prevOption) => ({ ...prevOption, link: link }));
                       field.onChange(link);
                     }}
                   />
                 )}
               />
-              {selectedOption.contactWay !== null && errors[selectedOption.contactWay] && (
-                <p>{String(errors[selectedOption.contactWay]?.message)}</p>
+              {selectedOptions.contactWay !== null && errors[selectedOptions.contactWay] && (
+                <p>{String(errors[selectedOptions.contactWay]?.message)}</p>
               )}
             </>
           )}
@@ -258,7 +247,7 @@ export default function RecruitmentRequestLayout({
           render={({ field }) => (
             <>
               <SelectPositionChipList
-                selectedPositions={selectedOption.positions}
+                selectedPositions={selectedOptions.positions}
                 onChipClick={(position) => {
                   handleSelectPosition(position);
                   field.onChange(position);
@@ -271,11 +260,15 @@ export default function RecruitmentRequestLayout({
       </S.SelectChipBox>
       <S.QuillBox>
         <h1>스터디/프로젝트 소개</h1>
-        <QuillEditor setSelectedOption={setSelectedOption} />
+        <QuillEditor setSelectedOptions={setSelectedOptions} />
       </S.QuillBox>
       <S.SubmitButtonBox>
         <Button variant="primaryLight">취소하기</Button>
-        <Button variant="primary" onClick={() => onSubmit(selectedOption)}>
+        <Button
+          variant="primary"
+          onClick={() => {
+            onSubmit(selectedOptions);
+          }}>
           {buttonText}
         </Button>
       </S.SubmitButtonBox>

--- a/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
+++ b/co-kkiri/src/components/commons/RecruitmentRequestLayout/index.tsx
@@ -11,14 +11,25 @@ import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
 import { format } from "date-fns";
 import LinkInput from "./LinkInput";
 import Button from "../Button";
-import { useForm, Controller, SubmitHandler, FieldValues } from "react-hook-form";
-import DESIGN_TOKEN from "@/styles/tokens";
-export default function RecruitmentRequestLayout() {
+import { useForm, Controller } from "react-hook-form";
+
+interface RecruitmentRequestLayoutProps {
+  onSubmit: (data: RecruitmentRequest) => void;
+  buttonText: string;
+  defaultOption?: RecruitmentRequest;
+}
+
+export default function RecruitmentRequestLayout({
+  onSubmit,
+  buttonText,
+  defaultOption,
+}: RecruitmentRequestLayoutProps) {
   const {
     recruitment: { capacity, progressPeriod, progressWay, contactWay },
   } = DROPDOWN_INFO;
-  const [selectedOption, setSelectedOption] = useState<RecruitmentRequest>({
-    type: "",
+
+  const initialOption: RecruitmentRequest = {
+    type: "STUDY",
     recruitEndAt: "",
     progressPeriod: "",
     capacity: undefined,
@@ -29,14 +40,18 @@ export default function RecruitmentRequestLayout() {
     title: "",
     content: "",
     link: "",
-  });
+  };
+
+  const [selectedOption, setSelectedOption] = useState<RecruitmentRequest>(
+    defaultOption ? defaultOption : initialOption,
+  );
 
   const findOptionByValue = <ValueType, OptionType>(values: ValueType[], options: OptionType[], value: ValueType) => {
     const index = values.indexOf(value);
     return options[index];
   };
 
-  const handleSelectType = (type: string): void => {
+  const handleSelectType = (type: "STUDY" | "PROJECT"): void => {
     setSelectedOption((prevOptions) => ({
       ...prevOptions,
       type: type,
@@ -60,14 +75,9 @@ export default function RecruitmentRequestLayout() {
   };
 
   const {
-    handleSubmit,
     control,
     formState: { errors },
   } = useForm();
-
-  const onSubmit: SubmitHandler<FieldValues> = (data) => {
-    console.log(data);
-  };
 
   return (
     <S.SelectContainer>
@@ -86,6 +96,7 @@ export default function RecruitmentRequestLayout() {
                 <>
                   <S.RadioButtonWarper>
                     <RadioButton
+                      defaultChecked
                       value="STUDY"
                       onClick={() => {
                         handleSelectType("STUDY");
@@ -261,8 +272,8 @@ export default function RecruitmentRequestLayout() {
       </S.QuillBox>
       <S.SubmitButtonBox>
         <Button variant="primaryLight">취소하기</Button>
-        <Button variant="primary" onClick={handleSubmit(onSubmit)}>
-          글 등록하기
+        <Button variant="primary" onClick={() => onSubmit(selectedOption)}>
+          {buttonText}
         </Button>
       </S.SubmitButtonBox>
     </S.SelectContainer>

--- a/co-kkiri/src/constants/dropDown.ts
+++ b/co-kkiri/src/constants/dropDown.ts
@@ -7,6 +7,7 @@ export const DROPDOWN_INFO = {
     position: {
       defaultValue: "포지션",
       options: ["풀스택", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
+      values: ["풀스택", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
     },
     career: {
       defaultValue: "경력",
@@ -17,36 +18,54 @@ export const DROPDOWN_INFO = {
   recruitment: {
     progressPeriod: {
       defaultValue: "진행 기간",
-      options: ["선택 미정", "1주", "2주", "3주", "1개월", "2개월", "3개월", "4개월", "5개월", "6개월", "6개월 이상"],
+      options: [
+        "협의 후 결정",
+        "1주",
+        "2주",
+        "3주",
+        "1개월",
+        "2개월",
+        "3개월",
+        "4개월",
+        "5개월",
+        "6개월",
+        "6개월 이상",
+      ],
+      values: [null, "1주", "2주", "3주", "1개월", "2개월", "3개월", "4개월", "5개월", "6개월", "6개월 이상"],
     },
     progressWay: {
       defaultValue: "진행 방식",
-      options: ["선택 미정", "온라인", "오프라인", "온/오프라인"],
+      options: ["온라인", "오프라인", "온/오프라인"],
+      values: ["온라인", "오프라인", "온/오프라인"],
     },
     capacity: {
       defaultValue: "모집 인원",
-      options: ["선택 미정", "1명", "2명", "3명", "4명", "5명", "6명", "7명", "8명", "9명", "10명 이상"],
+      options: ["인원 미정", "1명", "2명", "3명", "4명", "5명", "6명", "7명", "8명", "9명", "10명 이상"],
       values: [null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 999],
     },
     contactWay: {
       defaultValue: "연락 방식",
-      options: ["카카오 오픈톡", "이메일", "구글폼", "기타"],
-      placeholder: ["오픈톡 링크", "이메일 주소", "구글폼 주소"],
+      options: ["기타", "카카오 오픈톡", "이메일", "구글폼"],
+      values: [null, "카카오 오픈톡", "이메일", "구글폼"],
+      placeholder: [null, "오픈톡 링크", "이메일 주소", "구글폼 주소"],
     },
   },
   sort: {
     defaultValue: "최신순",
     options: [" 최신순", "마감순", "조회순"],
+    values: ["LATEST", "BYDEADLINE", "BYVIEW"],
   },
 
   filter: {
     position: {
       defaultValue: "포지션",
       options: ["전체", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
+      values: ["전체", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
     },
     progressWay: {
       defaultValue: "진행 방식",
       options: ["전체", "온라인", "오프라인", "온/오프라인"],
+      values: ["전체", "온라인", "오프라인", "온/오프라인"],
     },
   },
 

--- a/co-kkiri/src/lib/api/post/index.ts
+++ b/co-kkiri/src/lib/api/post/index.ts
@@ -26,11 +26,12 @@ export const getPostDetail = (postId: number): Promise<ApiRequestResponse<PostDe
   apiRequest("get", postAddress.postId(postId));
 
 /** 스터디 글 작성하기 */
-export const createPost = (data: RecruitApiRequestDto) => apiRequest("post", postAddress.recruit, data);
+export const createPost = (data: RecruitApiRequestDto) =>
+  apiRequest<PostDetailApiResponseDto, RecruitApiRequestDto>("post", postAddress.recruit, data);
 
 /** 스터디 글 수정하기 */
 export const modifyPost = (postId: number, data: RecruitApiRequestDto) =>
-  apiRequest("patch", postAddress.modify(postId), data);
+  apiRequest<PostDetailApiResponseDto, RecruitApiRequestDto>("patch", postAddress.modify(postId), data);
 
 /** 스터디 글 삭제하기 */
 export const deletePost = (postId: number) => apiRequest("delete", postAddress.postId(postId));

--- a/co-kkiri/src/lib/api/post/type.ts
+++ b/co-kkiri/src/lib/api/post/type.ts
@@ -2,15 +2,15 @@
 export type RecruitApiRequestDto = {
   type: "STUDY" | "PROJECT";
   recruitEndAt: string;
-  progressPeriod: string;
+  progressPeriod: string | null;
   capacity: number | null;
-  contactWay: string;
-  progressWay: string;
-  stacks: string[];
+  contactWay: string | null;
+  progressWay: string | null;
+  stacks: string[] | null;
   positions: string[];
-  title: string;
-  content: string;
-  link: string;
+  title: string | null;
+  content: string | null;
+  link: string | null;
 };
 
 type PostInfo = {
@@ -60,6 +60,7 @@ export type PostDetailApiResponseDto = {
   positions: string[];
   stacks: string[];
   commentsNum: number;
+  link: string;
 };
 /**스터디 지원 */
 export type ApplyPostApiRequestDto = {

--- a/co-kkiri/src/lib/api/post/type.ts
+++ b/co-kkiri/src/lib/api/post/type.ts
@@ -10,6 +10,7 @@ export type RecruitApiRequestDto = {
   positions: string[];
   title: string;
   content: string;
+  link: string;
 };
 
 type PostInfo = {

--- a/co-kkiri/src/lib/api/post/type.ts
+++ b/co-kkiri/src/lib/api/post/type.ts
@@ -3,7 +3,7 @@ export type RecruitApiRequestDto = {
   type: "STUDY" | "PROJECT";
   recruitEndAt: string;
   progressPeriod: string;
-  capacity: number;
+  capacity: number | null;
   contactWay: string;
   progressWay: string;
   stacks: string[];

--- a/co-kkiri/src/pages/Edit.tsx
+++ b/co-kkiri/src/pages/Edit.tsx
@@ -1,32 +1,56 @@
 import RecruitmentRequestLayout from "@/components/commons/RecruitmentRequestLayout";
 import * as S from "@/pages/Recruit/styled";
-import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
+import { RecruitApiRequestDto } from "@/lib/api/post/type";
 import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { modifyPost } from "@/lib/api/post";
+import { useNavigate } from "react-router-dom";
+import { getPostDetail } from "@/lib/api/post";
+import { useParams } from "react-router-dom";
 
 export default function Edit() {
-  const [defaultOption, setDefaultOption] = useState<RecruitmentRequest>({
-    type: "STUDY",
-    recruitEndAt: "",
-    progressPeriod: "",
-    capacity: undefined,
-    contactWay: "",
-    progressWay: "",
-    stacks: [],
-    positions: [],
-    title: "",
-    content: "",
-    link: "",
+  const [defaultOption, setDefaultOption] = useState<RecruitApiRequestDto>();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { postId } = useParams();
+
+  //포스트 아이디 값에 해당하는 데이터 블러오기
+  const { data } = useQuery({
+    queryKey: ["Post"],
+    queryFn: () => getPostDetail(+postId),
   });
 
-  const handleSubmit = async (selectedOptions: RecruitmentRequest) => {
-    console.log(selectedOptions);
+  //포스트 수정하는 요청 보내기
+  const editPost = useMutation({
+    mutationFn: (selectedOptions) => modifyPost(+postId, selectedOptions),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["post"] });
+      navigate(`/post/${postId}`);
+    },
+  });
+
+  //포스트 수정할떄 필요한 인자값 받아오기
+  const handleSubmit = (selectedOptions: RecruitApiRequestDto) => {
+    editPost.mutate(selectedOptions);
   };
 
-  const handleLodePost = () => {};
-
   useEffect(() => {
-    handleLodePost();
-  }, []);
+    //데이터가 있으면 state에 집어넣기
+    data &&
+      setDefaultOption({
+        title: data.postTitle,
+        content: data.postContent,
+        type: data.type,
+        recruitEndAt: data.recruitEndAt,
+        progressPeriod: data.progressPeriod,
+        progressWay: data.progressWay,
+        contactWay: data.contactWay,
+        capacity: data.capacity,
+        positions: data.positions,
+        stacks: data.stacks,
+        link: data.link,
+      });
+  }, [data]);
 
   return (
     <S.Container>

--- a/co-kkiri/src/pages/Edit.tsx
+++ b/co-kkiri/src/pages/Edit.tsx
@@ -1,3 +1,36 @@
+import RecruitmentRequestLayout from "@/components/commons/RecruitmentRequestLayout";
+import * as S from "@/pages/Recruit/styled";
+import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
+import { useEffect, useState } from "react";
+
 export default function Edit() {
-  return <div>Edit</div>;
+  const [defaultOption, setDefaultOption] = useState<RecruitmentRequest>({
+    type: "STUDY",
+    recruitEndAt: "",
+    progressPeriod: "",
+    capacity: undefined,
+    contactWay: "",
+    progressWay: "",
+    stacks: [],
+    positions: [],
+    title: "",
+    content: "",
+    link: "",
+  });
+
+  const handleSubmit = async (selectedOptions: RecruitmentRequest) => {
+    console.log(selectedOptions);
+  };
+
+  const handleLodePost = () => {};
+
+  useEffect(() => {
+    handleLodePost();
+  }, []);
+
+  return (
+    <S.Container>
+      <RecruitmentRequestLayout defaultOption={defaultOption} onSubmit={handleSubmit} buttonText="수정하기" />
+    </S.Container>
+  );
 }

--- a/co-kkiri/src/pages/Recruit/index.tsx
+++ b/co-kkiri/src/pages/Recruit/index.tsx
@@ -14,7 +14,6 @@ export default function Recruit() {
   const uploadPost = useMutation<ApiRequestResponse<PostDetailApiResponseDto>, Error, RecruitApiRequestDto>({
     mutationFn: (selectedOptions) => createPost(selectedOptions),
     onSuccess: (postId) => {
-      //업로드 성공하면 해당 모집글 상세페이지로 가야하는데 postId를 어떻게 받아가죠..?(url? 응답?)
       queryClient.invalidateQueries({ queryKey: ["posts"] }); // 키값은 나중에 물어보기
       navigate(`/post/${postId}`);
     },
@@ -22,7 +21,7 @@ export default function Recruit() {
 
   const handleSubmit = (selectedOptions: RecruitApiRequestDto) => {
     if (
-      selectedOptions.recruitEndAt !== null &&
+      selectedOptions.recruitEndAt !== "" &&
       selectedOptions.progressWay !== null &&
       selectedOptions.positions.length > 0
     ) {

--- a/co-kkiri/src/pages/Recruit/index.tsx
+++ b/co-kkiri/src/pages/Recruit/index.tsx
@@ -1,27 +1,16 @@
-import { useState } from "react";
 import RecruitmentRequestLayout from "@/components/commons/RecruitmentRequestLayout";
-import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
-
 import * as S from "./styled";
+import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
+import { useEffect } from "react";
 
 export default function Recruit() {
-  const [selectedOptions, setSelectedOptions] = useState<RecruitmentRequest>({
-    type: "",
-    recruitEndAt: "",
-    progressPeriod: "",
-    capacity: 0,
-    contactWay: "",
-    progressWay: "",
-    stacks: [],
-    positions: [],
-    title: "",
-    content: "",
-    link: "",
-  });
+  const handleSubmit = async (selectedOptions: RecruitmentRequest) => {
+    console.log(selectedOptions);
+  };
 
   return (
     <S.Container>
-      <RecruitmentRequestLayout />
+      <RecruitmentRequestLayout onSubmit={handleSubmit} buttonText="글 등록하기" />
     </S.Container>
   );
 }

--- a/co-kkiri/src/pages/Recruit/index.tsx
+++ b/co-kkiri/src/pages/Recruit/index.tsx
@@ -21,7 +21,16 @@ export default function Recruit() {
   });
 
   const handleSubmit = (selectedOptions: RecruitApiRequestDto) => {
-    uploadPost.mutate(selectedOptions);
+    if (
+      selectedOptions.recruitEndAt !== null &&
+      selectedOptions.progressWay !== null &&
+      selectedOptions.positions.length > 0
+    ) {
+      uploadPost.mutate(selectedOptions);
+    } else {
+      alert("필수값을 입력해주세요");
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
   };
 
   return (

--- a/co-kkiri/src/pages/Recruit/index.tsx
+++ b/co-kkiri/src/pages/Recruit/index.tsx
@@ -1,16 +1,17 @@
 import RecruitmentRequestLayout from "@/components/commons/RecruitmentRequestLayout";
 import * as S from "./styled";
-import { RecruitApiRequestDto } from "@/lib/api/post/type";
+import { PostDetailApiResponseDto, RecruitApiRequestDto } from "@/lib/api/post/type";
 import { createPost } from "@/lib/api/post";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { ApiRequestResponse } from "@/lib/api/axios";
 
 export default function Recruit() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   // 포스트 업로드하기
-  const uploadPost = useMutation({
+  const uploadPost = useMutation<ApiRequestResponse<PostDetailApiResponseDto>, Error, RecruitApiRequestDto>({
     mutationFn: (selectedOptions) => createPost(selectedOptions),
     onSuccess: (postId) => {
       //업로드 성공하면 해당 모집글 상세페이지로 가야하는데 postId를 어떻게 받아가죠..?(url? 응답?)

--- a/co-kkiri/src/pages/Recruit/index.tsx
+++ b/co-kkiri/src/pages/Recruit/index.tsx
@@ -1,11 +1,26 @@
 import RecruitmentRequestLayout from "@/components/commons/RecruitmentRequestLayout";
 import * as S from "./styled";
-import { RecruitmentRequest } from "@/types/recruitmentRequestTypes";
-import { useEffect } from "react";
+import { RecruitApiRequestDto } from "@/lib/api/post/type";
+import { createPost } from "@/lib/api/post";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 
 export default function Recruit() {
-  const handleSubmit = async (selectedOptions: RecruitmentRequest) => {
-    console.log(selectedOptions);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  // 포스트 업로드하기
+  const uploadPost = useMutation({
+    mutationFn: (selectedOptions) => createPost(selectedOptions),
+    onSuccess: (postId) => {
+      //업로드 성공하면 해당 모집글 상세페이지로 가야하는데 postId를 어떻게 받아가죠..?(url? 응답?)
+      queryClient.invalidateQueries({ queryKey: ["posts"] }); // 키값은 나중에 물어보기
+      navigate(`/post/${postId}`);
+    },
+  });
+
+  const handleSubmit = (selectedOptions: RecruitApiRequestDto) => {
+    uploadPost.mutate(selectedOptions);
   };
 
   return (

--- a/co-kkiri/src/pages/Recruit/styled.ts
+++ b/co-kkiri/src/pages/Recruit/styled.ts
@@ -1,7 +1,7 @@
 import DESIGN_TOKEN from "@/styles/tokens";
 import styled from "styled-components";
 
-const { typography, color, mediaQueries } = DESIGN_TOKEN;
+const { typography, color } = DESIGN_TOKEN;
 
 export const Container = styled.div`
   display: flex;

--- a/co-kkiri/src/types/recruitmentRequestTypes.ts
+++ b/co-kkiri/src/types/recruitmentRequestTypes.ts
@@ -1,5 +1,5 @@
 export interface RecruitmentRequest {
-  type: string;
+  type: "STUDY" | "PROJECT";
   recruitEndAt: string;
   progressPeriod: string;
   capacity: number | undefined | null;


### PR DESCRIPTION
### 📌요구사항

- [x] RecruitmentRequestLayout css 및 드랍다운 관련 내용 수정하기
- [x] api관련 함수 셋팅하기 및 버튼 비활성화 추가
- [ ] 리액트 훅 폼 Controller관련 리팩토링 하기

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- 이번에 작업하면서(쿼리셋팅, 요청처리)기술스택 부분에 오류가 있어서 나경님이랑 수정 해야할 것 같아 
   일단 주석 처리 하고 올리겠습니다
- 지금 리팩토링(리액트훅폼 컨트롤+드랍다운)을 하면 파일을 계속 옮겨 다니면서 작업해야 해서 
api연동까지만 확인 되면 리팩토링 해 놓겠습니다 ㅠ

- 지금 constants/dropDowns에 드랍버튼의 text가 options에 있는 값이 아닌 다른 값으로 보여져야 
  하는 곳이 모집글 작성, 수정 페이지 외에도 생길 수 있어서 일단 value 다 추가해 놨습니다 기능구현 하시다 
  비슷한 문제가 발생하면 value를 참고해서 사용하시면 될 것 같습니다

- 링크 유효성 검사를 통과 못하면 글 작성이 안되는 걸까요..?-? 현재는 링크 입력창은 요청 조건에 넣진 않았습니다
- 필수 입력값을 안넣으면 또 스크롤해서 올라가는게 불편해서 알림창 띄우고 최상단으로 스크롤 가게 해놨는데
  괜찮은지 확인 부탁 드립니다!!

### 📌스크린샷 / 테스트결과 (선택)
![모집글 페이지 시연](https://github.com/co-KKIRI/FE_co-KKIRI/assets/114739219/18b4e13f-c4c8-4f15-b97c-dd9ececb60bb)


### 📌이슈 번호
close #147 