### PR TITLE
Refector: navigation 리팩토링

### DIFF
--- a/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
+++ b/co-kkiri/src/components/commons/Gnb/Gnb.styled.ts
@@ -60,6 +60,31 @@ export const PostButton = styled.div`
   }
 `;
 
+export const UserInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+
+  img {
+    border-radius: 50%;
+  }
+`;
+
+export const ProfileImg = styled.img`
+  width: 3.6rem;
+  height: 3.6rem;
+  object-fit: cover;
+`;
+
+export const Nickname = styled.div`
+  ${typography.font14Medium}
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+`;
+
 export const SignButton = styled.button`
   ${typography.font14Medium};
   &:hover {

--- a/co-kkiri/src/components/commons/Gnb/GnbUserInfo.tsx
+++ b/co-kkiri/src/components/commons/Gnb/GnbUserInfo.tsx
@@ -1,0 +1,24 @@
+import { IMAGES } from "@/constants/images";
+import * as S from "./Gnb.styled";
+
+interface GnbUserInfoProps {
+  user: {
+    id: number;
+    nickname: string;
+    profileImageUrl: string;
+  };
+  onClick: () => void;
+}
+
+export default function GnbUserInfo({ user, onClick }: GnbUserInfoProps) {
+  return (
+    <S.UserInfoWrapper onClick={onClick}>
+      {user.profileImageUrl ? (
+        <S.ProfileImg src={user.profileImageUrl} alt="프로필 사진" />
+      ) : (
+        <img src={IMAGES.profileImg.src} alt={IMAGES.profileImg.alt} />
+      )}
+      <S.Nickname>{user.nickname}</S.Nickname>
+    </S.UserInfoWrapper>
+  );
+}

--- a/co-kkiri/src/components/commons/Gnb/index.tsx
+++ b/co-kkiri/src/components/commons/Gnb/index.tsx
@@ -1,17 +1,17 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import * as S from "./Gnb.styled";
 import { ROUTER_PATH } from "@/lib/path";
 import { ICONS } from "@/constants/icons";
 import { IMAGES } from "@/constants/images";
-import UserInfo from "../UserInfo";
 import UserPopover from "../UserPopover";
 import AuthModal from "@/components/modals/AuthModal";
 import useOpenToggle from "@/hooks/useOpenToggle";
 import useAuthModalToggleStore from "@/stores/authModalToggle";
+import GnbUserInfo from "./GnbUserInfo";
 
 interface GnbProps {
   user?: {
+    id: number;
     nickname: string;
     profileImageUrl: string;
   };
@@ -45,7 +45,7 @@ export default function Gnb({ user, onSideBarClick }: GnbProps) {
             <S.PostButton>스터디 모집하기</S.PostButton>
           </Link>
           {user ? (
-            <UserInfo user={user} onClick={handlePopoverOpen} />
+            <GnbUserInfo user={user} onClick={handlePopoverOpen} />
           ) : (
             <S.SignButton onClick={toggleAuthModal}>로그인/회원가입</S.SignButton>
           )}

--- a/co-kkiri/src/components/commons/SideBar/index.tsx
+++ b/co-kkiri/src/components/commons/SideBar/index.tsx
@@ -20,7 +20,7 @@ export default function SideBar({ onClick, onClose }: SideBarProps) {
         </ModalLayout>
       ) : (
         <S.Background>
-          <SideBarList onClick={onClick} />
+          <SideBarList />
         </S.Background>
       )}
     </>

--- a/co-kkiri/src/components/commons/UserPopover.tsx
+++ b/co-kkiri/src/components/commons/UserPopover.tsx
@@ -34,8 +34,6 @@ const { typography, mediaQueries, color, boxShadow, zIndex } = DESIGN_TOKEN;
 const Container = styled.div<{ $isPopoverOpen: boolean }>`
   ${zIndex.popover}
   display: ${({ $isPopoverOpen }) => ($isPopoverOpen ? "block" : "none")};
-  opacity: ${({ $isPopoverOpen }) => ($isPopoverOpen ? 1 : 0)};
-  transition: opacity 0.2s ease-in-out;
   position: absolute;
   right: 4rem;
 

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -6,10 +6,8 @@ import Gnb from "@/components/commons/Gnb";
 import SideBar from "@/components/commons/SideBar";
 import { useWindowSize } from "usehooks-ts";
 import { slideIn, slideOut } from "@/utils/animation";
-import { useState } from "react";
 
 export default function Navigation() {
-  const [isOpen, setIsOpen] = useState(false);
   const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
   const toggleSideBar = useSideBarStore((state) => state.toggleSideBar);
 
@@ -25,8 +23,8 @@ export default function Navigation() {
       <Gnb onSideBarClick={handleSideBar} />
       <SideBarWrapper $isOpen={isSideBarOpen}>
         {isSideBarOpen && isTabletOrMobile && <SideBar onClick={handleSideBar} onClose={handleSideBar} />}
+        {!isTabletOrMobile && <SideBar onClose={() => {}} />}
       </SideBarWrapper>
-      <SideBarWrapper $isOpen={isSideBarOpen}>{!isTabletOrMobile && <SideBar onClose={() => {}} />}</SideBarWrapper>
       <OutletWrapper $isOpen={isSideBarOpen}>
         <Outlet />
       </OutletWrapper>

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -6,30 +6,27 @@ import Gnb from "@/components/commons/Gnb";
 import SideBar from "@/components/commons/SideBar";
 import { useWindowSize } from "usehooks-ts";
 import { slideIn, slideOut } from "@/utils/animation";
+import { useState } from "react";
 
 export default function Navigation() {
+  const [isOpen, setIsOpen] = useState(false);
   const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
   const toggleSideBar = useSideBarStore((state) => state.toggleSideBar);
 
   const { width: screenWidth } = useWindowSize();
   const isTabletOrMobile = screenWidth < 1200;
 
-  const handleSideBarOpen = () => {
+  const handleSideBar = () => {
     toggleSideBar();
   };
 
   return (
     <>
-      <Gnb onSideBarClick={handleSideBarOpen} />
-      {isSideBarOpen && (
-        <SideBarWrapper $isOpen={isSideBarOpen}>
-          {isTabletOrMobile ? (
-            isSideBarOpen && <SideBar onClick={handleSideBarOpen} onClose={handleSideBarOpen} />
-          ) : (
-            <SideBar onClose={() => {}} />
-          )}
-        </SideBarWrapper>
-      )}
+      <Gnb onSideBarClick={handleSideBar} />
+      <SideBarWrapper $isOpen={isSideBarOpen}>
+        {isSideBarOpen && isTabletOrMobile && <SideBar onClick={handleSideBar} onClose={handleSideBar} />}
+      </SideBarWrapper>
+      <SideBarWrapper $isOpen={isSideBarOpen}>{!isTabletOrMobile && <SideBar onClose={() => {}} />}</SideBarWrapper>
       <OutletWrapper $isOpen={isSideBarOpen}>
         <Outlet />
       </OutletWrapper>


### PR DESCRIPTION
### 📌요구사항
- [x] 데스크탑 환경에서 사이드바 닫히는 애니메이션 적용
- [x] 로그인됐을 경우 gnb userInfo 리팩토링

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- 애니메이션 적용을 했지만, 새로고침시에 다시 메롱하는 현상이 발생해버리네요...........ㅠㅠ
  - 둘중 하나로 결정해놓고 나중에 생각해봐야겠습니다.
- GnbUserInfo 컴포넌트 분리(대부분 쓰이는 유저인포는 클릭 시 유저 정보 모달이 뜨게되므로 gnb용 userInfo 추가)
  - 추후 중복 코드 리팩토링 가능성 있음

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/09e4fe85-19e8-456f-88a0-6e6a3f5e2ce0


https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/ede2a7f8-f88e-460b-864b-0eb8421ea0f7


https://github.com/co-KKIRI/FE_co-KKIRI/assets/148832727/c3c63558-1283-4093-b732-6fa4eb4cac3c



### 📌이슈 번호
