### PR TITLE
Feat: /member/info/summary API 연결

### DIFF
--- a/co-kkiri/src/components/commons/AuthListener.ts
+++ b/co-kkiri/src/components/commons/AuthListener.ts
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 import { googleLogin } from "@/lib/api/auth";
 import useAuthModalToggleStore from "@/stores/authModalToggle";
+import { useUserInfoStore } from "@/stores/userInfoStore";
 
 const AuthListener = () => {
   const setIsAuthModalOpen = useAuthModalToggleStore((state) => state.setIsAuthModalOpen);
+  const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
 
   const getAccessToken = async (code: string) => {
     const response = await googleLogin(code);
@@ -11,9 +13,10 @@ const AuthListener = () => {
   };
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
+    const handleMessage = async (event: MessageEvent) => {
       if (event.data && event.data.type === "OAuthSuccess") {
-        getAccessToken(event.data.code);
+        await getAccessToken(event.data.code);
+        await fetchUserInfo();
         setIsAuthModalOpen(false);
       }
     };
@@ -23,7 +26,7 @@ const AuthListener = () => {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, [setIsAuthModalOpen]);
+  }, [fetchUserInfo, setIsAuthModalOpen]);
 
   return null;
 };

--- a/co-kkiri/src/components/commons/Gnb/GnbUserInfo.tsx
+++ b/co-kkiri/src/components/commons/Gnb/GnbUserInfo.tsx
@@ -1,12 +1,9 @@
 import { IMAGES } from "@/constants/images";
 import * as S from "./Gnb.styled";
+import { UserProfile } from "@/types/userTypes";
 
 interface GnbUserInfoProps {
-  user: {
-    id: number;
-    nickname: string;
-    profileImageUrl: string;
-  };
+  user: UserProfile;
   onClick: () => void;
 }
 

--- a/co-kkiri/src/components/commons/Gnb/index.tsx
+++ b/co-kkiri/src/components/commons/Gnb/index.tsx
@@ -21,6 +21,7 @@ export default function Gnb({ onSideBarClick }: GnbProps) {
 
   const isAuthModalOpen = useAuthModalToggleStore((state) => state.isAuthModalOpen);
   const toggleAuthModal = useAuthModalToggleStore((state) => state.toggleAuthModal);
+  const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
   const user = useUserInfoStore((state) => state.userInfo);
   const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
 

--- a/co-kkiri/src/components/commons/Gnb/index.tsx
+++ b/co-kkiri/src/components/commons/Gnb/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import * as S from "./Gnb.styled";
 import { ROUTER_PATH } from "@/lib/path";
@@ -8,26 +9,28 @@ import AuthModal from "@/components/modals/AuthModal";
 import useOpenToggle from "@/hooks/useOpenToggle";
 import useAuthModalToggleStore from "@/stores/authModalToggle";
 import GnbUserInfo from "./GnbUserInfo";
+import { useUserInfoStore } from "@/stores/userInfoStore";
 
 interface GnbProps {
-  user?: {
-    id: number;
-    nickname: string;
-    profileImageUrl: string;
-  };
   onSideBarClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function Gnb({ user, onSideBarClick }: GnbProps) {
+export default function Gnb({ onSideBarClick }: GnbProps) {
   const { HOME_PATH, RECRUIT_PATH } = ROUTER_PATH;
   const { ref, isOpen: isPopoverOpen, openToggle: togglePopover } = useOpenToggle();
 
   const isAuthModalOpen = useAuthModalToggleStore((state) => state.isAuthModalOpen);
   const toggleAuthModal = useAuthModalToggleStore((state) => state.toggleAuthModal);
+  const user = useUserInfoStore((state) => state.userInfo);
+  const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
 
   const handlePopoverOpen = () => {
     togglePopover();
   };
+
+  useEffect(() => {
+    fetchUserInfo();
+  }, [fetchUserInfo]);
 
   return (
     <S.Container ref={ref}>
@@ -51,7 +54,7 @@ export default function Gnb({ user, onSideBarClick }: GnbProps) {
           )}
         </S.RightGroupWrapper>
       </S.Box>
-      {isAuthModalOpen && <AuthModal onClick={toggleAuthModal} onClose={toggleAuthModal} />}
+      {isAuthModalOpen && <AuthModal onClose={toggleAuthModal} />}
       {user && <UserPopover isPopoverOpen={isPopoverOpen} handleSelectOption={handlePopoverOpen} />}
     </S.Container>
   );

--- a/co-kkiri/src/components/commons/UserInfo.tsx
+++ b/co-kkiri/src/components/commons/UserInfo.tsx
@@ -3,6 +3,7 @@ import DESIGN_TOKEN from "@/styles/tokens";
 import { useState } from "react";
 import { styled } from "styled-components";
 import UserProfileModal from "../modals/UserProfileModal";
+import { UserProfile } from "@/types/userTypes";
 interface UserInfoProps {
   user: {
     id?: number;

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -12,7 +12,6 @@ import { useUserInfoStore } from "@/stores/userInfoStore";
 export default function Navigation() {
   const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
   const toggleSideBar = useSideBarStore((state) => state.toggleSideBar);
-  const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
 
   const { width: screenWidth } = useWindowSize();
   const isTabletOrMobile = screenWidth < 1200;
@@ -20,10 +19,6 @@ export default function Navigation() {
   const handleSideBar = () => {
     toggleSideBar();
   };
-
-  useEffect(() => {
-    fetchUserInfo();
-  }, [fetchUserInfo]);
 
   return (
     <>

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -6,8 +6,6 @@ import Gnb from "@/components/commons/Gnb";
 import SideBar from "@/components/commons/SideBar";
 import { useWindowSize } from "usehooks-ts";
 import { slideIn, slideOut } from "@/utils/animation";
-import { useEffect } from "react";
-import { useUserInfoStore } from "@/stores/userInfoStore";
 
 export default function Navigation() {
   const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);

--- a/co-kkiri/src/layouts/Navigation.tsx
+++ b/co-kkiri/src/layouts/Navigation.tsx
@@ -6,10 +6,13 @@ import Gnb from "@/components/commons/Gnb";
 import SideBar from "@/components/commons/SideBar";
 import { useWindowSize } from "usehooks-ts";
 import { slideIn, slideOut } from "@/utils/animation";
+import { useEffect } from "react";
+import { useUserInfoStore } from "@/stores/userInfoStore";
 
 export default function Navigation() {
   const isSideBarOpen = useSideBarStore((state) => state.isSideBarOpen);
   const toggleSideBar = useSideBarStore((state) => state.toggleSideBar);
+  const fetchUserInfo = useUserInfoStore((state) => state.fetchUserInfo);
 
   const { width: screenWidth } = useWindowSize();
   const isTabletOrMobile = screenWidth < 1200;
@@ -17,6 +20,10 @@ export default function Navigation() {
   const handleSideBar = () => {
     toggleSideBar();
   };
+
+  useEffect(() => {
+    fetchUserInfo();
+  }, [fetchUserInfo]);
 
   return (
     <>

--- a/co-kkiri/src/lib/api/address.ts
+++ b/co-kkiri/src/lib/api/address.ts
@@ -96,8 +96,14 @@ export const myPostAddress = {
   reviewInfo: "/my-post/complete/review/info",
 };
 
-//get
-export const memberAddress = { memberId: (memberId: number) => `/member/${memberId}`, search: "/member/search" };
+export const memberAddress = {
+  //get
+  userInfoSummary: "/member/info/summary",
+  //get
+  memberId: (memberId: number) => `/member/${memberId}`,
+  //get
+  search: "/member/search",
+};
 
 //post
 export const imageAddress = "/image";

--- a/co-kkiri/src/lib/api/auth/index.ts
+++ b/co-kkiri/src/lib/api/auth/index.ts
@@ -1,6 +1,10 @@
-import { authAddress } from "../address";
+import { authAddress, memberAddress } from "../address";
 import { apiRequest } from "../axios";
+import { UserInfoSummaryResponseDto } from "./type";
 
 const { google } = authAddress;
 
 export const googleLogin = (code: string) => apiRequest("post", google.redirect(code));
+
+export const getUserInfoSummary = (): Promise<UserInfoSummaryResponseDto> =>
+  apiRequest("get", memberAddress.userInfoSummary);

--- a/co-kkiri/src/lib/api/auth/type.ts
+++ b/co-kkiri/src/lib/api/auth/type.ts
@@ -1,0 +1,4 @@
+export type UserInfoSummaryResponseDto = {
+  nickname: string;
+  profileImageUrl: string;
+};

--- a/co-kkiri/src/stores/userInfoStore.ts
+++ b/co-kkiri/src/stores/userInfoStore.ts
@@ -1,30 +1,47 @@
+import { getUserInfoSummary } from "@/lib/api/auth";
+import { UserInfoSummaryResponseDto } from "@/lib/api/auth/type";
 import { SetterFromState } from "@/types/objectUtilTypes";
 import { UserProfile } from "@/types/userTypes";
 import { create } from "zustand";
 
 interface UserInfoState {
   userId: number | null;
-  userInfo: UserProfile;
+  userInfo: UserProfile | null;
   isVisible: boolean;
 }
 
 type UserInfoSetter = SetterFromState<UserInfoState>;
 
-export const useUserInfoStore = create<UserInfoState & UserInfoSetter>((set) => ({
+type UserInfoActions = {
+  fetchUserInfo: () => Promise<void>;
+};
+
+type UserInfoStore = UserInfoState & UserInfoSetter & UserInfoActions;
+
+export const useUserInfoStore = create<UserInfoStore>((set) => ({
   userId: null,
   profileImage: undefined,
-  userInfo: {
-    nickname: "",
-    profileImageUrl: "",
-    position: "",
-    career: undefined,
-    introduce: "",
-    stacks: [],
-    link: "",
-  },
+  userInfo: null,
   isVisible: false,
 
   setUserId: (userId) => set({ userId }),
   setUserInfo: (userInfo) => set({ userInfo }),
   setIsVisible: (isVisible) => set({ isVisible }),
+  fetchUserInfo: async () => {
+    try {
+      const data: UserInfoSummaryResponseDto = await getUserInfoSummary();
+      const userProfile: UserProfile = {
+        nickname: data.nickname,
+        profileImageUrl: data.profileImageUrl,
+        position: "",
+        career: undefined,
+        introduce: "",
+        stacks: [],
+        link: "",
+      };
+      set({ userInfo: userProfile });
+    } catch (error) {
+      console.error("Failed to fetch user info:", error);
+    }
+  },
 }));

--- a/co-kkiri/src/stores/userInfoStore.ts
+++ b/co-kkiri/src/stores/userInfoStore.ts
@@ -7,6 +7,7 @@ import { create } from "zustand";
 interface UserInfoState {
   userId: number | null;
   userInfo: UserProfile | null;
+  isLoading: boolean;
   isVisible: boolean;
 }
 
@@ -22,15 +23,18 @@ export const useUserInfoStore = create<UserInfoStore>((set) => ({
   userId: null,
   profileImage: undefined,
   userInfo: null,
+  isLoading: true,
   isVisible: false,
 
   setUserId: (userId) => set({ userId }),
   setUserInfo: (userInfo) => set({ userInfo }),
+  setIsLoading: (isLoading) => set({ isLoading }),
   setIsVisible: (isVisible) => set({ isVisible }),
   fetchUserInfo: async () => {
+    let userProfile: UserProfile | null = null;
     try {
       const data: UserInfoSummaryResponseDto = await getUserInfoSummary();
-      const userProfile: UserProfile = {
+      userProfile = {
         nickname: data.nickname,
         profileImageUrl: data.profileImageUrl,
         position: "",
@@ -39,9 +43,10 @@ export const useUserInfoStore = create<UserInfoStore>((set) => ({
         stacks: [],
         link: "",
       };
-      set({ userInfo: userProfile });
     } catch (error) {
       console.error("Failed to fetch user info:", error);
+    } finally {
+      set({ userInfo: userProfile, isLoading: false });
     }
   },
 }));


### PR DESCRIPTION
### 📌요구사항
- [x] /member/info/summary API 연결

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- zustand로 유저 정보 관리 및 fetch 함수 관리하기
- 페이지 접속 시 /member/info/summary request 보내기
- google Oauth 완료 시 /member/info/summary request 보내기
- 서버를 껐다 켜면 쿠키가 있어도 리퀘스트가 401 에러가 나는 오류가 있음

### 📌스크린샷 / 테스트결과 (선택)
- 테스트 결과

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/79a4c72a-b0c1-4aca-90d7-ac82ee4c538f

- 창 닫았다가 켜보기

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/fae48179-57f5-42f1-a808-6c5afa0013ef

### 📌이슈 번호
close #169 