### PR TITLE
Refactor: 유저 정보를 가져오는 api를 /member/info/summary에서 /my-page/info로 바꿈

### DIFF
--- a/co-kkiri/src/stores/userInfoStore.ts
+++ b/co-kkiri/src/stores/userInfoStore.ts
@@ -1,5 +1,5 @@
-import { getUserInfoSummary } from "@/lib/api/auth";
-import { UserInfoSummaryResponseDto } from "@/lib/api/auth/type";
+import { getUserInfo } from "@/lib/api/myPage";
+import { UserInfoApiResponseDto } from "@/lib/api/myPage/type";
 import { SetterFromState } from "@/types/objectUtilTypes";
 import { UserProfile } from "@/types/userTypes";
 import { create } from "zustand";
@@ -33,15 +33,16 @@ export const useUserInfoStore = create<UserInfoStore>((set) => ({
   fetchUserInfo: async () => {
     let userProfile: UserProfile | null = null;
     try {
-      const data: UserInfoSummaryResponseDto = await getUserInfoSummary();
+      const data: UserInfoApiResponseDto = await getUserInfo();
+      const { nickname, profileImageUrl, position, career, introduce, link } = data;
       userProfile = {
-        nickname: data.nickname,
-        profileImageUrl: data.profileImageUrl,
-        position: "",
-        career: undefined,
-        introduce: "",
-        stacks: [],
-        link: "",
+        nickname,
+        profileImageUrl,
+        position,
+        career,
+        introduce,
+        stacks: data.stack,
+        link,
       };
     } catch (error) {
       console.error("Failed to fetch user info:", error);


### PR DESCRIPTION
### 📌요구사항
- [x] 유저 정보를 가져오는 api를 /member/info/summary에서 /my-page/info로 바꿈

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- 유저 정보를 가져오는 api를 /member/info/summary에서 /my-page/info로 바꿈

### 📌스크린샷 / 테스트결과 (선택)
- api에서 받아온 데이터(위)와 zustand에 저장한 데이터(아래)
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/0fc0e62e-f3d9-4e10-aefc-ecbfecb5ddaf)


### 📌이슈 번호
