### PR TITLE
Fix: 프로젝트 상세 요약 카드 연락 방식을  ContactWay와 link 값에 따라 구분

### DIFF
--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -43,7 +43,7 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
         if (typeof content === "object" && "label" in content) {
           switch (content.label) {
             case "기타": {
-              return <RowContent>기타 {content.content || "afdasdfasdfaasdfadfasfadfasdf"}</RowContent>;
+              return <RowContent>기타 {content.content || ""}</RowContent>;
             }
             case "카카오 오픈톡": {
               return <Link label="카카오 오픈톡" to={content.content || ""} icon={ICONS.link} linkType="external" />;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -20,12 +20,12 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
     switch (renderType) {
       case "text":
         if (typeof content === "string") {
-          return <p>{content}</p>;
+          return <RowContent>{content}</RowContent>;
         }
         break;
       case "capacity":
         if (typeof content === "number") {
-          return <p>{content}명</p>;
+          return <RowContent>{content}명</RowContent>;
         }
         break;
       case "positions":
@@ -73,7 +73,7 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
       <Label>
         <span>{label}</span>
       </Label>
-      {renderContent()}
+      <Box>{renderContent()}</Box>
     </Container>
   );
 }
@@ -93,6 +93,11 @@ const Container = styled.div`
   }
 `;
 
+const Box = styled.div`
+  //Label의 크기만큼 작아짐
+  width: calc(100% - 10rem);
+`;
+
 const Label = styled.div`
   width: 10rem;
   color: ${color.gray[1]};
@@ -107,4 +112,11 @@ const Stacks = styled(DefaultStacks)`
   flex-wrap: wrap;
   flex-shrink: 1;
   gap: 0.8rem;
+`;
+
+const RowContent = styled.p`
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -6,6 +6,7 @@ import DefaultStacks from "../Stacks";
 import DefaultPositions from "../Positions";
 import Link from "../Link";
 import { ICONS } from "@/constants/icons";
+import { getEmailLink } from "@/utils/validationUtils";
 
 export interface ProjectDetailRowProps {
   label: string;
@@ -37,10 +38,32 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
           return <Stacks stacks={content} />;
         }
         break;
-      case "link":
+      case "contactWay":
         // 타입 가드를 사용하여 Link 컴포넌트임을 보장
-        if (typeof content === "object" && "to" in content) {
-          return <Link {...content} icon={ICONS.link} />;
+        if (typeof content === "object" && "label" in content) {
+          switch (content.label) {
+            case "기타": {
+              return <RowContent>기타 {content.content || "afdasdfasdfaasdfadfasfadfasdf"}</RowContent>;
+            }
+            case "카카오 오픈톡": {
+              return <Link label="카카오 오픈톡" to={content.content || ""} icon={ICONS.link} linkType="external" />;
+            }
+            case "구글폼": {
+              return <Link label="구글폼" to={content.content || ""} icon={ICONS.link} linkType="external" />;
+            }
+            case "이메일": {
+              return (
+                <Link
+                  label="이메일"
+                  to={content.content ? getEmailLink(content.content) : ""}
+                  icon={ICONS.link}
+                  linkType="external"
+                />
+              );
+            }
+            default:
+              return <p>준비 중</p>;
+          }
         }
     }
   }, [content, renderType]);

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -39,8 +39,7 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
         }
         break;
       case "contactWay":
-        // 타입 가드를 사용하여 Link 컴포넌트임을 보장
-        if (typeof content === "object" && "label" in content) {
+        if (typeof content === "object" && "label" in content && "content" in content) {
           switch (content.label) {
             case "기타": {
               return <RowContent>기타 {content.content || ""}</RowContent>;

--- a/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/ProjectDetailRow.tsx
@@ -42,18 +42,18 @@ export default function ProjectDetailRow({ label, content, renderType }: Project
         if (typeof content === "object" && "label" in content && "content" in content) {
           switch (content.label) {
             case "기타": {
-              return <RowContent>기타 {content.content || ""}</RowContent>;
+              return <RowContent>{content.label}</RowContent>;
             }
             case "카카오 오픈톡": {
-              return <Link label="카카오 오픈톡" to={content.content || ""} icon={ICONS.link} linkType="external" />;
+              return <Link label={content.label} to={content.content || ""} icon={ICONS.link} linkType="external" />;
             }
             case "구글폼": {
-              return <Link label="구글폼" to={content.content || ""} icon={ICONS.link} linkType="external" />;
+              return <Link label={content.label} to={content.content || ""} icon={ICONS.link} linkType="external" />;
             }
             case "이메일": {
               return (
                 <Link
-                  label="이메일"
+                  label={content.label}
                   to={content.content ? getEmailLink(content.content) : ""}
                   icon={ICONS.link}
                   linkType="external"

--- a/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/index.tsx
@@ -32,7 +32,7 @@ export default function ProjectDetailCard({ type, ProjectCategory, ...projectDet
     contactWay: {
       label: "연락 방식",
       content: projectDetailContents.contactWay,
-      renderType: "link",
+      renderType: "contactWay",
     },
     capacity: {
       label: "모집 인원",

--- a/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
+++ b/co-kkiri/src/components/commons/ProjectDetailCard/types.ts
@@ -1,5 +1,8 @@
 import { GetTypeFromObject } from "@/types/objectUtilTypes";
-import { LinkProps as Link } from "../Link";
+
+//TODO: DROPDOWN_FORM_INFO keyof typeof로 타입을 만들어서 전달해야 함
+export type ContactWay = "기타" | "카카오 오픈톡" | "이메일" | "구글폼";
+type ContactWayInfo = { label: ContactWay | null; content: string | null };
 
 // ProjectDetailCard내 Table에서 사용되는 Key
 export type ProjectDetailKey =
@@ -12,8 +15,8 @@ export type ProjectDetailKey =
   | "stacks";
 
 // 구체적인 렌더링 방식
-export type RenderType = "text" | "positions" | "stacks" | "capacity" | "link";
-export type ContentType = string | string[] | number | Link;
+export type RenderType = "text" | "positions" | "stacks" | "capacity" | "contactWay";
+export type ContentType = string | string[] | number | ContactWayInfo;
 // ProjectDetailCard 내부에서 Table에게 전달할 Table Config
 export type ProjectDetailConfig = {
   [key in ProjectDetailKey]: {

--- a/co-kkiri/src/components/domains/detail/DetailCard.tsx
+++ b/co-kkiri/src/components/domains/detail/DetailCard.tsx
@@ -1,4 +1,5 @@
 import ProjectDetailCard from "@/components/commons/ProjectDetailCard";
+import { ContactWay } from "@/components/commons/ProjectDetailCard/types";
 import { PostDetails } from "@/lib/api/post/type";
 import { formatDate } from "@/utils/formatDate";
 
@@ -20,7 +21,7 @@ export default function DetailCard({ postDetails, className, cardRef }: DetailCa
         progressPeriod={progressPeriod}
         positions={positions}
         progressWay={progressWay}
-        contactWay={{ label: contactWay, to: "https://www.naver.com", linkType: "external" }}
+        contactWay={{ label: contactWay as ContactWay, content: link }}
         capacity={capacity}
         stacks={stacks}
       />

--- a/co-kkiri/src/utils/validationUtils.ts
+++ b/co-kkiri/src/utils/validationUtils.ts
@@ -2,40 +2,37 @@ export function isValidHexColor(color: string): boolean {
   return /^#[0-9A-F]{6}$/i.test(color);
 }
 
-
 /**
  * 주어진 값이 '비어 있는' 상태인지 여부를 확인합니다.
- * 
+ *
  * 이 함수는 다음과 같은 경우에 '비어 있음'으로 간주합니다:
  * - 객체가 `null`이거나 키가 없는 경우
  * - 배열의 길이가 0인 경우
  * - 문자열이 빈 문자열이거나 공백만 있는 경우
  * - 값이 'falsy' 값이지만, `0`은 '비어 있지 않음'으로 처리합니다 (예: `false`, `undefined`, `NaN`은 '비어 있음'으로 간주).
- * 
+ *
  * 이 함수는 폼 입력값 검사, 데이터 처리 로직 등에서 특정 값의 존재 여부를 확인할 때 유용하게 사용될 수 있습니다.
  *
  * @template T - 함수가 처리할 수 있는 값의 타입입니다.
  *
  * @param {T} value - 확인하고자 하는 값. `string`, `object`, `number`, `boolean`, `null`, `undefined` 등 다양한 타입을 받을 수 있습니다.
- * 
+ *
  * @returns {boolean} - 값이 '비어 있는' 경우 `true`, 그렇지 않은 경우 `false`를 반환합니다.
- * 
+ *
  * @example
  * // 문자열이 비어있는 경우
  * console.log(isEmptyValue("")); // true
- * 
+ *
  * // 객체가 비어있는 경우
  * console.log(isEmptyValue({})); // true
- * 
+ *
  * // 숫자 0은 '비어 있지 않음'으로 처리
  * console.log(isEmptyValue(0)); // false
- * 
+ *
  * // null은 '비어 있음'으로 처리
  * console.log(isEmptyValue(null)); // true
  */
-export function isEmptyValue<T>(
-  value: T,
-): boolean {
+export function isEmptyValue<T>(value: T): boolean {
   // 객체나 배열이 비어 있는지 확인
   if (typeof value === "object" && (value === null || Object.keys(value).length === 0)) {
     return true;
@@ -53,3 +50,13 @@ export function isEmptyValue<T>(
 
   return false;
 }
+
+export const getEmailLink = (email: string): string => {
+  const emailReg = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+  if (!emailReg.test(email)) {
+    throw new Error("Invalid email address");
+  }
+
+  return `mailto:${email}`;
+};


### PR DESCRIPTION
### 📌요구사항
- [x] 프로젝트 상세 요약 카드 연락 방식을  ContactWay와 link 값에 따라 구분

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
# ProjectDetailCard 변경점
## 이제 받아오는 contactWay값에 따라 표시를 구분합니다
>ContactWay 및 link 값에 따라 프로젝트 상세 요약 카드의 연락 방식을 구분할 수 있게 되었습니다.

```tsx
  case "contactWay":
    // 타입 가드를 사용하여 Link 컴포넌트임을 보장
    if (typeof content === "object" && "label" in content) {
      switch (content.label) {
        case "기타": {
          return <RowContent>기타 {content.content || ""}</RowContent>;
        }
        case "카카오 오픈톡": {
          return <Link label="카카오 오픈톡" to={content.content || ""} icon={ICONS.link} linkType="external" />;
        }
        case "구글폼": {
          return <Link label="구글폼" to={content.content || ""} icon={ICONS.link} linkType="external" />;
        }
        case "이메일": {
          return (
            <Link
              label="이메일"
              to={content.content ? getEmailLink(content.content) : ""}
              icon={ICONS.link}
              linkType="external"
            />
          );
        }
        default:
          return <p>준비 중</p>;
      }
    }
```
## 이메일 검증 및 주소 반환 유틸리티가 생겼습니다
> 현재는 값을 받아와서 표시할 때 쓰고있는데, 개인적으로는 `link`라는 단어에 걸맞게, 애초에 보낼 때 `getEmailLink`를 사용해서 변환 후 보내야할 것 같습니다.

```tsx
export const getEmailLink = (email: string): string => {
  const emailReg = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
  if (!emailReg.test(email)) {
    throw new Error("Invalid email address");
  }
  return `mailto:${email}`;
};
```

<br/>

### 사담
- 기타일 때 어떻게 표현할지 고민하다가, 그냥 기타 뒤에 붙이는 걸로 합의 봤는데, 어떻게 생각하시는지요?

### 📌스크린샷 / 테스트결과 (선택)
![상세카드](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/28a1baf4-fccd-4e33-af2a-ddb974bd9b46)


### 📌이슈 번호
Closes: #170 