### PR TITLE
Feat: FormElement 로직 구현 & 유저 스카우트 후 초대 모달

### DIFF
--- a/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
@@ -3,13 +3,14 @@ import SquareDropButton from "./commons/SquareDropButton";
 import DropMenu from "./commons/DropMenu";
 import styled from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
+import { Option } from "../Form/RHFDropdown";
 
 interface DropdownProps {
   placeholder: string;
   selectedOption?: string | null;
-  options: string[];
+  options: Option[];
   isError?: boolean;
-  onSelect: (option: string) => void;
+  onSelect: (option: Option) => void;
   dropdownRef?: React.RefCallback<HTMLButtonElement>;
 }
 
@@ -23,7 +24,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const { isOpen, openToggle: toggleDropdown, ref } = useOpenToggle();
 
-  const handleSelectOption = (option: string) => {
+  const handleSelectOption = (option: Option) => {
     onSelect(option);
     toggleDropdown();
   };

--- a/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
@@ -2,16 +2,27 @@ import useOpenToggle from "@/hooks/useOpenToggle";
 import SquareDropButton from "./commons/SquareDropButton";
 import DropMenu from "./commons/DropMenu";
 import styled from "styled-components";
+import DESIGN_TOKEN from "@/styles/tokens";
 
 interface DropdownProps {
   placeholder: string;
   selectedOption?: string | null;
   options: string[];
+  isError?: boolean;
+  helperText?: string;
   onSelect: (option: string) => void;
   dropdownRef?: React.RefCallback<HTMLButtonElement>;
 }
 
-export default function Dropdown({ placeholder, selectedOption, options, onSelect, dropdownRef }: DropdownProps) {
+export default function Dropdown({
+  placeholder,
+  selectedOption,
+  options,
+  onSelect,
+  isError,
+  helperText,
+  dropdownRef,
+}: DropdownProps) {
   const { isOpen, openToggle: toggleDropdown, ref } = useOpenToggle();
 
   const handleSelectOption = (option: string) => {
@@ -27,17 +38,30 @@ export default function Dropdown({ placeholder, selectedOption, options, onSelec
         $isSelected={!!selectedOption}
         $iconType="default"
         dropButtonRef={dropdownRef}
+        isError={isError}
       />
+      <HelperText>{helperText}</HelperText>
       <DropMenu isOpen={isOpen} handleSelectOption={handleSelectOption} $borderType="square" options={options} />
     </Container>
   );
 }
 
-const Container = styled.div`
+const { color, typography } = DESIGN_TOKEN;
+interface ContainerProps {
+  $isError?: boolean;
+}
+
+const Container = styled.div<ContainerProps>`
   width: 100%;
   display: flex;
   flex-direction: column;
   position: relative;
   padding: 0;
   gap: 0.8rem;
+`;
+
+const HelperText = styled.p`
+  text-align: start;
+  color: ${color.red};
+  ${typography.font12Medium}
 `;

--- a/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/Dropdown.tsx
@@ -9,7 +9,6 @@ interface DropdownProps {
   selectedOption?: string | null;
   options: string[];
   isError?: boolean;
-  helperText?: string;
   onSelect: (option: string) => void;
   dropdownRef?: React.RefCallback<HTMLButtonElement>;
 }
@@ -20,7 +19,6 @@ export default function Dropdown({
   options,
   onSelect,
   isError,
-  helperText,
   dropdownRef,
 }: DropdownProps) {
   const { isOpen, openToggle: toggleDropdown, ref } = useOpenToggle();
@@ -40,7 +38,6 @@ export default function Dropdown({
         dropButtonRef={dropdownRef}
         isError={isError}
       />
-      <HelperText>{helperText}</HelperText>
       <DropMenu isOpen={isOpen} handleSelectOption={handleSelectOption} $borderType="square" options={options} />
     </Container>
   );
@@ -58,10 +55,4 @@ const Container = styled.div<ContainerProps>`
   position: relative;
   padding: 0;
   gap: 0.8rem;
-`;
-
-const HelperText = styled.p`
-  text-align: start;
-  color: ${color.red};
-  ${typography.font12Medium}
 `;

--- a/co-kkiri/src/components/commons/DropDowns/commons/DropMenu.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/DropMenu.tsx
@@ -24,13 +24,13 @@ interface ContainerProps {
 export default function DropMenu({ options, isOpen, handleSelectOption, $borderType }: DropdownMenuProps) {
   return (
     <Container $isOpen={isOpen} $borderType={$borderType}>
-      {options.map((option: string) => (
+      {options.map((option: string, index: number) => (
         <Option
           $borderType={$borderType}
           onClick={() => {
             handleSelectOption(option);
           }}
-          key={option}>
+          key={`${option}-${index}`}>
           {option}
         </Option>
       ))}

--- a/co-kkiri/src/components/commons/DropDowns/commons/DropMenu.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/DropMenu.tsx
@@ -1,9 +1,10 @@
 import styled, { css } from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
+import { Option } from "../../Form/RHFDropdown";
 
-interface DropdownMenuProps {
-  options: string[];
-  handleSelectOption: (option: string) => void;
+interface DropdownMenuProps<ValueType = string> {
+  options: Option[];
+  handleSelectOption: (option: Option) => void;
   isOpen: boolean;
   $borderType: "round" | "square";
 }
@@ -24,14 +25,14 @@ interface ContainerProps {
 export default function DropMenu({ options, isOpen, handleSelectOption, $borderType }: DropdownMenuProps) {
   return (
     <Container $isOpen={isOpen} $borderType={$borderType}>
-      {options.map((option: string, index: number) => (
+      {options.map((option: Option, index: number) => (
         <Option
           $borderType={$borderType}
           onClick={() => {
             handleSelectOption(option);
           }}
           key={`${option}-${index}`}>
-          {option}
+          {option.label}
         </Option>
       ))}
     </Container>

--- a/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
+++ b/co-kkiri/src/components/commons/DropDowns/commons/SquareDropButton.tsx
@@ -9,6 +9,7 @@ interface DropdownButtonProps {
   onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   $iconType: "date" | "default";
   $isSelected: boolean;
+  isError?: boolean;
   dropButtonRef?: RefObject<HTMLButtonElement> | RefCallBack;
 }
 
@@ -16,6 +17,7 @@ interface ContainerProps {
   $iconType: "date" | "default";
   $isSelected: boolean;
   $isReactElement: boolean;
+  $isError?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function SquareDropButton({
   onClick,
   $iconType,
   $isSelected,
+  isError,
   dropButtonRef,
 }: DropdownButtonProps) {
   const iconSources = {
@@ -46,6 +49,7 @@ export default function SquareDropButton({
       $iconType={$iconType}
       $isSelected={$isSelected}
       $isReactElement={typeof selectOption !== "string"}
+      $isError={isError}
       ref={dropButtonRef}>
       <Box>{selectOption}</Box>
       <img src={iconSources[$iconType].src} alt={iconSources[$iconType].alt} />
@@ -72,6 +76,11 @@ const Container = styled.button<ContainerProps>`
   & img {
     width: 1.8rem;
   }
+
+  ${({ $isError }) =>
+    $isError &&
+    `  border-color: ${color.red};
+`}
 `;
 
 const Box = styled.div`

--- a/co-kkiri/src/components/commons/Form/FormDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/FormDropdown.tsx
@@ -40,6 +40,8 @@ const Container = styled.div`
 `;
 
 const HelperText = styled.p`
+  min-height: 1.5rem;
+
   color: ${color.red};
   ${typography.font12Medium}
 `;

--- a/co-kkiri/src/components/commons/Form/FormDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/FormDropdown.tsx
@@ -1,0 +1,27 @@
+import Dropdown from "../DropDowns/Dropdown";
+import { InputProps } from "./FormElement";
+
+interface FormDropdownProps extends InputProps {
+  placeholder: string;
+  options: string[];
+}
+
+export default function FormDropdown({
+  placeholder,
+  value,
+  options,
+  onChange,
+  isError,
+  helperText,
+}: FormDropdownProps) {
+  return (
+    <Dropdown
+      placeholder={placeholder}
+      selectedOption={value}
+      options={options}
+      onSelect={onChange}
+      helperText={helperText}
+      isError={isError}
+    />
+  );
+}

--- a/co-kkiri/src/components/commons/Form/FormDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/FormDropdown.tsx
@@ -1,5 +1,7 @@
+import styled from "styled-components";
 import Dropdown from "../DropDowns/Dropdown";
 import { InputProps } from "./FormElement";
+import DESIGN_TOKEN from "@/styles/tokens";
 
 interface FormDropdownProps extends InputProps {
   placeholder: string;
@@ -15,13 +17,28 @@ export default function FormDropdown({
   helperText,
 }: FormDropdownProps) {
   return (
-    <Dropdown
-      placeholder={placeholder}
-      selectedOption={value}
-      options={options}
-      onSelect={onChange}
-      helperText={helperText}
-      isError={isError}
-    />
+    <Container>
+      <Dropdown
+        placeholder={placeholder}
+        selectedOption={value}
+        options={options}
+        onSelect={onChange}
+        isError={isError}
+      />
+      <HelperText>{helperText}</HelperText>
+    </Container>
   );
 }
+
+const { color, typography } = DESIGN_TOKEN;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+const HelperText = styled.p`
+  color: ${color.red};
+  ${typography.font12Medium}
+`;

--- a/co-kkiri/src/components/commons/Form/FormDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/FormDropdown.tsx
@@ -2,10 +2,11 @@ import styled from "styled-components";
 import Dropdown from "../DropDowns/Dropdown";
 import { FormFieldProps } from "./FormElement";
 import DESIGN_TOKEN from "@/styles/tokens";
+import { Option } from "./RHFDropdown";
 
-interface FormDropdownProps extends FormFieldProps {
+interface FormDropdownProps extends FormFieldProps<Option> {
   placeholder: string;
-  options: string[];
+  options: Option[];
 }
 
 export default function FormDropdown({
@@ -20,7 +21,7 @@ export default function FormDropdown({
     <Container>
       <Dropdown
         placeholder={placeholder}
-        selectedOption={value}
+        selectedOption={value.label}
         options={options}
         onSelect={onChange}
         isError={isError}

--- a/co-kkiri/src/components/commons/Form/FormDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/FormDropdown.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import Dropdown from "../DropDowns/Dropdown";
-import { InputProps } from "./FormElement";
+import { FormFieldProps } from "./FormElement";
 import DESIGN_TOKEN from "@/styles/tokens";
 
-interface FormDropdownProps extends InputProps {
+interface FormDropdownProps extends FormFieldProps {
   placeholder: string;
   options: string[];
 }

--- a/co-kkiri/src/components/commons/Form/FormElement.tsx
+++ b/co-kkiri/src/components/commons/Form/FormElement.tsx
@@ -2,20 +2,24 @@ import React from "react";
 import styled from "styled-components";
 import Label from "./Label";
 
-export interface FormFieldProps {
-  onChange: (value: string) => void;
-  value: string;
+export interface FormFieldProps<ValueType> {
+  onChange: (value: ValueType) => void;
+  value: ValueType;
   isError?: boolean;
   helperText?: string;
 }
 
-interface FormElementProps {
+interface FormElementProps<ValueType> {
   label: string;
   isEssential?: boolean;
-  FormFieldComponent: React.ReactElement<FormFieldProps>;
+  FormFieldComponent: React.ReactElement<FormFieldProps<ValueType>>;
 }
 
-export default function FormElement({ label, isEssential, FormFieldComponent: InputComponent }: FormElementProps) {
+export default function FormElement<ValueType>({
+  label,
+  isEssential,
+  FormFieldComponent: InputComponent,
+}: FormElementProps<ValueType>) {
   return (
     <Container>
       <Label label={label} isEssential={isEssential} />

--- a/co-kkiri/src/components/commons/Form/FormElement.tsx
+++ b/co-kkiri/src/components/commons/Form/FormElement.tsx
@@ -6,7 +6,7 @@ export interface InputProps {
   onChange: (value: string) => void;
   value: string;
   isError?: boolean;
-  helperText: string;
+  helperText?: string;
 }
 
 interface FormElementProps {

--- a/co-kkiri/src/components/commons/Form/FormElement.tsx
+++ b/co-kkiri/src/components/commons/Form/FormElement.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import Label from "./Label";
 
-export interface InputProps {
+export interface FormFieldProps {
   onChange: (value: string) => void;
   value: string;
   isError?: boolean;
@@ -12,10 +12,10 @@ export interface InputProps {
 interface FormElementProps {
   label: string;
   isEssential?: boolean;
-  InputComponent: React.ReactElement<InputProps>;
+  FormFieldComponent: React.ReactElement<FormFieldProps>;
 }
 
-export default function FormElement({ label, isEssential, InputComponent }: FormElementProps) {
+export default function FormElement({ label, isEssential, FormFieldComponent: InputComponent }: FormElementProps) {
   return (
     <Container>
       <Label label={label} isEssential={isEssential} />

--- a/co-kkiri/src/components/commons/Form/FormElement.tsx
+++ b/co-kkiri/src/components/commons/Form/FormElement.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+import Label from "./Label";
+
+export interface InputProps {
+  onChange: (value: string) => void;
+  value: string;
+  isError?: boolean;
+  helperText: string;
+}
+
+interface FormElementProps {
+  label: string;
+  isEssential?: boolean;
+  InputComponent: React.ReactElement<InputProps>;
+}
+
+export default function FormElement({ label, isEssential, InputComponent }: FormElementProps) {
+  return (
+    <Container>
+      <Label label={label} isEssential={isEssential} />
+      {InputComponent}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+`;

--- a/co-kkiri/src/components/commons/Form/FormTextarea.tsx
+++ b/co-kkiri/src/components/commons/Form/FormTextarea.tsx
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+import DefaultTextarea from "../Textarea";
+import DESIGN_TOKEN from "@/styles/tokens";
+
+interface FormTextAreaProps {
+  id: string;
+  placeholder: string;
+  value: string;
+  defaultContent?: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  isError?: boolean;
+  helperText?: string;
+}
+
+export default function FormTextArea({
+  id,
+  placeholder,
+  value,
+  onChange,
+  isError,
+  helperText,
+}: FormTextAreaProps) {
+  return (
+    <Container>
+      <Textarea
+        type="modal"
+        id={id}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        $isError={isError}
+        //화면 크기 감지해서 row 값 정해야함
+        rows={5}
+      />
+      <HelperText>{helperText}</HelperText>
+    </Container>
+  );
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+interface TextareaProps {
+  $isError?: boolean;
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+const Textarea = styled(DefaultTextarea)<TextareaProps>`
+  border-color: ${({ $isError }) => $isError && `${color.red}`};
+`;
+
+const HelperText = styled.p`
+  color: ${color.red};
+  ${typography.font12Medium}
+`;

--- a/co-kkiri/src/components/commons/Form/FormTextarea.tsx
+++ b/co-kkiri/src/components/commons/Form/FormTextarea.tsx
@@ -29,7 +29,7 @@ export default function FormTextArea({
         value={value}
         onChange={onChange}
         $isError={isError}
-        //화면 크기 감지해서 row 값 정해야함
+        //TODO: 화면 크기 감지해서 row 값 정해야함
         rows={5}
       />
       <HelperText>{helperText}</HelperText>

--- a/co-kkiri/src/components/commons/Form/FormTextarea.tsx
+++ b/co-kkiri/src/components/commons/Form/FormTextarea.tsx
@@ -12,14 +12,7 @@ interface FormTextAreaProps {
   helperText?: string;
 }
 
-export default function FormTextArea({
-  id,
-  placeholder,
-  value,
-  onChange,
-  isError,
-  helperText,
-}: FormTextAreaProps) {
+export default function FormTextArea({ id, placeholder, value, onChange, isError, helperText }: FormTextAreaProps) {
   return (
     <Container>
       <Textarea
@@ -32,7 +25,7 @@ export default function FormTextArea({
         //TODO: 화면 크기 감지해서 row 값 정해야함
         rows={5}
       />
-      <HelperText>{helperText}</HelperText>
+      {helperText && <HelperText>{helperText}</HelperText>}
     </Container>
   );
 }

--- a/co-kkiri/src/components/commons/Form/Label.tsx
+++ b/co-kkiri/src/components/commons/Form/Label.tsx
@@ -1,0 +1,27 @@
+import DESIGN_TOKEN from "@/styles/tokens";
+import styled from "styled-components";
+
+interface LabelProps {
+  label: string;
+  isEssential?: boolean;
+}
+
+export default function Label({ label, isEssential }: LabelProps) {
+  return (
+    <Container>
+      {label}
+      {isEssential && <span> *</span>}
+    </Container>
+  );
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const Container = styled.label`
+  color: ${color.black[1]};
+  ${typography.font16Bold}
+
+  & > span {
+    color: ${color.red};
+  }
+`;

--- a/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
@@ -33,7 +33,7 @@ export default function RHFDropdown<ControlType extends FieldValues>({
           placeholder={placeholder}
           value={options.find((option) => option.value === field.value) || { label: "", value: "" }}
           options={options}
-          onChange={(option) => {
+          onChange={(option: Option) => {
             field.onChange(option.value);
           }}
           isError={fieldState.invalid}

--- a/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
@@ -1,28 +1,28 @@
 import { Control, Controller, FieldValues, Path } from "react-hook-form";
 import FormDropdown from "./FormDropdown";
 
-export type Option<ValueType> = {
+export type Option = {
   label: string;
-  value: ValueType;
+  value: unknown;
 };
 
-interface RHFDropdownProps<ControlType extends FieldValues, ValueType> {
+interface RHFDropdownProps<ControlType extends FieldValues> {
   placeholder: string;
-  options: Option<ValueType>[];
+  options: Option[];
   formFieldName: Path<ControlType>;
   control: Control<ControlType>;
   isEssential?: boolean;
   errorMessage?: string;
 }
 
-export default function RHFDropdown<ControlType extends FieldValues, ValueType>({
+export default function RHFDropdown<ControlType extends FieldValues>({
   placeholder,
   options,
   formFieldName,
   control,
   isEssential,
   errorMessage,
-}: RHFDropdownProps<ControlType, ValueType>) {
+}: RHFDropdownProps<ControlType>) {
   return (
     <Controller
       name={formFieldName}
@@ -31,9 +31,11 @@ export default function RHFDropdown<ControlType extends FieldValues, ValueType>(
       render={({ field, fieldState }) => (
         <FormDropdown
           placeholder={placeholder}
-          value={field.value}
+          value={options.find((option) => option.value === field.value) || { label: "", value: "" }}
           options={options}
-          onChange={field.onChange}
+          onChange={(option) => {
+            field.onChange(option.value);
+          }}
           isError={fieldState.invalid}
           helperText={fieldState.error?.message}
         />

--- a/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
@@ -1,0 +1,38 @@
+import { Control, Controller, FieldValues, Path } from "react-hook-form";
+import FormDropdown from "./FormDropdown";
+
+interface RHFDropdownProps<ControlType extends FieldValues> {
+  placeholder: string;
+  options: string[];
+  formFieldName: Path<ControlType>;
+  control: Control<ControlType>;
+  isEssential?: boolean;
+  errorMessage?: string;
+}
+
+export default function RHFDropdown<ControlType extends FieldValues>({
+  placeholder,
+  options,
+  formFieldName,
+  control,
+  isEssential,
+  errorMessage,
+}: RHFDropdownProps<ControlType>) {
+  return (
+    <Controller
+      name={formFieldName}
+      control={control}
+      rules={isEssential ? { required: errorMessage || "필수 입력사항입니다" } : {}}
+      render={({ field, fieldState }) => (
+        <FormDropdown
+          placeholder={placeholder}
+          value={field.value}
+          options={options}
+          onChange={field.onChange}
+          isError={fieldState.invalid}
+          helperText={fieldState.error?.message}
+        />
+      )}
+    />
+  );
+}

--- a/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
+++ b/co-kkiri/src/components/commons/Form/RHFDropdown.tsx
@@ -1,23 +1,28 @@
 import { Control, Controller, FieldValues, Path } from "react-hook-form";
 import FormDropdown from "./FormDropdown";
 
-interface RHFDropdownProps<ControlType extends FieldValues> {
+export type Option<ValueType> = {
+  label: string;
+  value: ValueType;
+};
+
+interface RHFDropdownProps<ControlType extends FieldValues, ValueType> {
   placeholder: string;
-  options: string[];
+  options: Option<ValueType>[];
   formFieldName: Path<ControlType>;
   control: Control<ControlType>;
   isEssential?: boolean;
   errorMessage?: string;
 }
 
-export default function RHFDropdown<ControlType extends FieldValues>({
+export default function RHFDropdown<ControlType extends FieldValues, ValueType>({
   placeholder,
   options,
   formFieldName,
   control,
   isEssential,
   errorMessage,
-}: RHFDropdownProps<ControlType>) {
+}: RHFDropdownProps<ControlType, ValueType>) {
   return (
     <Controller
       name={formFieldName}

--- a/co-kkiri/src/components/commons/Form/RHFTextArea.tsx
+++ b/co-kkiri/src/components/commons/Form/RHFTextArea.tsx
@@ -1,0 +1,36 @@
+import { Control, Controller, FieldValues, Path } from "react-hook-form";
+import FormTextArea from "./FormTextarea";
+
+interface RHFDropdownProps<ControlType extends FieldValues> {
+  placeholder: string;
+  formFieldName: Path<ControlType>;
+  control: Control<ControlType>;
+  isEssential?: boolean;
+  errorMessage?: string;
+}
+
+export default function RHFTextArea<ControlType extends FieldValues>({
+  formFieldName,
+  control,
+  isEssential,
+  errorMessage,
+  placeholder,
+}: RHFDropdownProps<ControlType>) {
+  return (
+    <Controller
+      name={formFieldName}
+      control={control}
+      rules={isEssential ? { required: errorMessage || "필수 입력사항입니다" } : {}}
+      render={({ field, fieldState }) => (
+        <FormTextArea
+          id={formFieldName}
+          placeholder={placeholder}
+          value={field.value}
+          onChange={field.onChange}
+          isError={fieldState.invalid}
+          helperText={fieldState.error?.message}
+        />
+      )}
+    />
+  );
+}

--- a/co-kkiri/src/components/commons/Textarea/Textarea.styled.ts
+++ b/co-kkiri/src/components/commons/Textarea/Textarea.styled.ts
@@ -28,7 +28,7 @@ const TEXTAREA_TYPE: VariantStyle<TextareaType> = {
     background-color: ${color.white};
     width: 100%;
     //height: 미정
-    //padding: 미정
+    padding: 1rem 2rem;
   `,
 };
 

--- a/co-kkiri/src/components/commons/Textarea/index.tsx
+++ b/co-kkiri/src/components/commons/Textarea/index.tsx
@@ -6,10 +6,11 @@ export type TextareaType = "comment" | "modal";
 interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   type: TextareaType;
   defaultContent?: string;
+  className?: string;
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { id, type, placeholder, value, onChange, ...props },
+  { id, type, placeholder, value, onChange, className, ...props },
   ref,
 ) {
   return (
@@ -21,6 +22,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textare
       value={value || ""}
       onChange={onChange}
       ref={ref}
+      className={className}
       {...props}
     />
   );

--- a/co-kkiri/src/components/modals/ScoutModal/ScoutUserProfile.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/ScoutUserProfile.tsx
@@ -30,7 +30,9 @@ const Container = styled.div`
 const Profile = styled.img`
   width: 4.8rem;
   height: 4.8rem;
+
   border-radius: 9999rem;
+  border: 0.1rem solid ${color.gray[3]};
 
   object-fit: cover;
 `;

--- a/co-kkiri/src/components/modals/ScoutModal/ScoutUserProfile.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/ScoutUserProfile.tsx
@@ -1,0 +1,41 @@
+import PositionChip from "@/components/commons/Chips/PositionChip";
+import { IMAGES } from "@/constants/images";
+import DESIGN_TOKEN from "@/styles/tokens";
+import styled from "styled-components";
+
+interface ScoutUserProfileProps {
+  nickname: string;
+  profileImageUrl?: string;
+  position?: string;
+}
+
+export default function ScoutUserProfile({ nickname, profileImageUrl, position }: ScoutUserProfileProps) {
+  return (
+    <Container>
+      <Profile src={profileImageUrl || IMAGES.profileImg.src} alt={IMAGES.profileImg.alt} />
+      <Nickname>{nickname}</Nickname>
+      {position && <PositionChip label={position} />}
+    </Container>
+  );
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const Container = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+`;
+
+const Profile = styled.img`
+  width: 4.8rem;
+  height: 4.8rem;
+  border-radius: 9999rem;
+
+  object-fit: cover;
+`;
+
+const Nickname = styled.p`
+  color: ${color.black[1]};
+  ${typography.font16Medium}
+`;

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -8,21 +8,21 @@ import { InviteMemberRequestDto, ScoutListApiResponseDto, ScoutPost } from "../.
 import { useForm } from "react-hook-form";
 import RHFTextArea from "../../commons/Form/RHFTextArea";
 import { useQueries } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { MemberProfileApiResponseDto } from "@/lib/api/member/type";
 import { MemberProfile } from "../../../lib/api/member/type";
 import ScoutUserProfile from "./ScoutUserProfile";
-import { Nickname } from "../../commons/UserProfileCard/UserProfileCardLayout.styled";
 
 interface ScoutModalProps {
   memberId: number;
 }
 
+type CombinedResults = {
+  options: ScoutPost[];
+  userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position">;
+};
+
 export default function ScoutModal({ memberId }: ScoutModalProps) {
-  const results = useQueries<
-    (ScoutListApiResponseDto | MemberProfileApiResponseDto)[],
-    { options: ScoutPost[]; userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position"> }
-  >({
+  const results = useQueries<(ScoutListApiResponseDto | MemberProfileApiResponseDto)[], CombinedResults>({
     queries: [
       {
         //TODO: 스카우트를 위한 현재 초대 가능한 스터디/프로젝트 목록 가져오기
@@ -73,10 +73,16 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
     mode: "onSubmit",
   });
 
+
   return (
     <ModalLayout desktopWidth={430} mobileWidth={320} onClose={() => {}}>
       <Title>유저 초대하기</Title>
-      <FormBox onSubmit={handleSubmit((data) => console.log(data))}>
+      <FormBox onSubmit={handleSubmit((data) => console.log(data)
+        // 데이터 매핑처리
+
+
+        // mutate
+        )}>
         <FormElement
           label="초대할 유저"
           InputComponent={

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -85,7 +85,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
         )}>
         <FormElement
           label="초대할 유저"
-          InputComponent={
+          FormFieldComponent={
             <ScoutUserProfile
               nickname={results.userInfo.nickname}
               profileImageUrl={results.userInfo.profileImageUrl}
@@ -95,7 +95,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
         />
         <FormElement
           label="스터디/프로젝트 선택"
-          InputComponent={
+          FormFieldComponent={
             <RHFDropdown
               formFieldName="postId"
               placeholder="스터디/프로젝트 선택"
@@ -110,7 +110,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
         />
         <FormElement
           label="초대 메시지"
-          InputComponent={
+          FormFieldComponent={
             <RHFTextArea formFieldName="message" placeholder="초대 메시지를 입력해주세요" control={control} />
           }
         />

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -61,27 +61,29 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
       <Title>유저 초대하기</Title>
       <FormBox onSubmit={handleSubmit(onSubmitHandler)}>
         <FormElement label="초대할 유저" FormFieldComponent={<ScoutUserProfile {...values.userInfo} />} />
-        <FormElement
-          label="스터디/프로젝트 선택"
-          FormFieldComponent={
-            <RHFDropdown
-              formFieldName="postId"
-              placeholder="스터디/프로젝트 선택"
-              //TODO: 실 데이터 가져와야함
-              options={values.options}
-              control={control}
-              errorMessage="스터디/프로젝트를 선택해주세요"
-              isEssential
-            />
-          }
-          isEssential
-        />
-        <FormElement
-          label="초대 메시지"
-          FormFieldComponent={
-            <RHFTextArea formFieldName="message" placeholder="초대 메시지를 입력해주세요" control={control} />
-          }
-        />
+        <Wrapper>
+          <FormElement
+            label="스터디/프로젝트 선택"
+            FormFieldComponent={
+              <RHFDropdown
+                formFieldName="postId"
+                placeholder="스터디/프로젝트 선택"
+                //TODO: 실 데이터 가져와야함
+                options={values.options}
+                control={control}
+                errorMessage="스터디/프로젝트를 선택해주세요"
+                isEssential
+              />
+            }
+            isEssential
+          />
+          <FormElement
+            label="초대 메시지"
+            FormFieldComponent={
+              <RHFTextArea formFieldName="message" placeholder="초대 메시지를 입력해주세요" control={control} />
+            }
+          />
+        </Wrapper>
         <Button variant="primary">초대하기</Button>
       </FormBox>
     </ModalLayout>
@@ -96,6 +98,12 @@ const ModalLayout = styled(DefaultModalLayout)`
   display: flex;
   flex-direction: column;
   gap: 6rem;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.7rem;
 `;
 
 const Title = styled.h1`

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -3,7 +3,7 @@ import DefaultModalLayout from "../ModalLayout";
 import DESIGN_TOKEN from "@/styles/tokens";
 import Button from "../../commons/Button";
 import FormElement from "../../commons/Form/FormElement";
-import RHFDropdown from "../../commons/Form/RHFDropdown";
+import RHFDropdown, { Option } from "../../commons/Form/RHFDropdown";
 import { InviteMemberRequestDto, ScoutListApiResponseDto, ScoutPost } from "../../../lib/api/post/type";
 import { useForm } from "react-hook-form";
 import RHFTextArea from "../../commons/Form/RHFTextArea";
@@ -17,7 +17,7 @@ interface ScoutModalProps {
 }
 
 type CombinedResults = {
-  options: ScoutPost[];
+  options: Option<number>[];
   userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position">;
 };
 
@@ -34,7 +34,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
             { postId: 4, title: "프로젝트 파트너 찾아요" },
             { postId: 5, title: "프론트엔드 개발자 모집" },
             { postId: 6, title: "백엔드 개발자 모집" },
-            { postId: 7, title: "풀스택 개발자 모집" },
+            { postId: 7, title: "백엔드 개발자 모집" },
             { postId: 8, title: "디자이너 모집" },
             { postId: 9, title: "기획자 모집" },
             { postId: 10, title: "테스터 모집" },
@@ -55,12 +55,12 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
       },
     ],
     combine: (results) => {
-      console.log(results);
-      const options = results[0].data as ScoutListApiResponseDto;
+      const rawOptions = results[0].data as ScoutListApiResponseDto;
+      const options = rawOptions.data.map<Option<number>>((option) => ({ value: option.postId, label: option.title }));
       const {
         memberProfile: { nickname, profileImageUrl, position },
       } = results[1].data as MemberProfileApiResponseDto;
-      return { options: options.data, userInfo: { nickname, profileImageUrl, position } };
+      return { options: options, userInfo: { nickname, profileImageUrl, position } };
     },
   });
 
@@ -73,15 +73,15 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
     mode: "onSubmit",
   });
 
-
   return (
     <ModalLayout desktopWidth={430} mobileWidth={320} onClose={() => {}}>
       <Title>유저 초대하기</Title>
-      <FormBox onSubmit={handleSubmit((data) => console.log(data)
-        // 데이터 매핑처리
+      <FormBox
+        onSubmit={handleSubmit(
+          (data) => console.log(data),
+          // 데이터 매핑처리
 
-
-        // mutate
+          // mutate
         )}>
         <FormElement
           label="초대할 유저"
@@ -100,7 +100,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
               formFieldName="postId"
               placeholder="스터디/프로젝트 선택"
               //TODO: 실 데이터 가져와야함
-              options={results.options.map((option) => option.title)}
+              options={results.options}
               control={control}
               errorMessage="스터디/프로젝트를 선택해주세요"
               isEssential

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -50,18 +50,16 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
     mode: "onSubmit",
   });
 
-  const onSubmitHandler = () => {
-    handleSubmit((data) => {
-      const mappedData = mapSubmitData(values, data);
-      console.log(mappedData);
-      //TODO: mutate
-    });
+  const onSubmitHandler = (data: InviteMemberRequestDto) => {
+    const mappedData = mapSubmitData(values, data);
+    console.log(mappedData);
+    //TODO: mutate
   };
 
   return (
     <ModalLayout desktopWidth={430} mobileWidth={320} onClose={() => {}}>
       <Title>유저 초대하기</Title>
-      <FormBox onSubmit={onSubmitHandler}>
+      <FormBox onSubmit={handleSubmit(onSubmitHandler)}>
         <FormElement label="초대할 유저" FormFieldComponent={<ScoutUserProfile {...values.userInfo} />} />
         <FormElement
           label="스터디/프로젝트 선택"
@@ -84,9 +82,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
             <RHFTextArea formFieldName="message" placeholder="초대 메시지를 입력해주세요" control={control} />
           }
         />
-        <Button type="submit" variant="primary">
-          초대하기
-        </Button>
+        <Button variant="primary">초대하기</Button>
       </FormBox>
     </ModalLayout>
   );
@@ -106,6 +102,7 @@ const Title = styled.h1`
   color: ${color.black[1]};
   ${typography.font20Bold}
 `;
+
 const FormBox = styled.form`
   width: 100%;
 

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -1,0 +1,140 @@
+import styled from "styled-components";
+import DefaultModalLayout from "../ModalLayout";
+import DESIGN_TOKEN from "@/styles/tokens";
+import Button from "../../commons/Button";
+import FormElement from "../../commons/Form/FormElement";
+import RHFDropdown from "../../commons/Form/RHFDropdown";
+import { InviteMemberRequestDto, ScoutListApiResponseDto, ScoutPost } from "../../../lib/api/post/type";
+import { useForm } from "react-hook-form";
+import RHFTextArea from "../../commons/Form/RHFTextArea";
+import { useQueries } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { MemberProfileApiResponseDto } from "@/lib/api/member/type";
+import { MemberProfile } from "../../../lib/api/member/type";
+import ScoutUserProfile from "./ScoutUserProfile";
+import { Nickname } from "../../commons/UserProfileCard/UserProfileCardLayout.styled";
+
+interface ScoutModalProps {
+  memberId: number;
+}
+
+export default function ScoutModal({ memberId }: ScoutModalProps) {
+  const results = useQueries<
+    (ScoutListApiResponseDto | MemberProfileApiResponseDto)[],
+    { options: ScoutPost[]; userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position"> }
+  >({
+    queries: [
+      {
+        //스카우트를 위한 현재 초대 가능한 스터디/프로젝트 목록 가져오기
+        queryKey: ["post", "scout"],
+        initialData: {
+          data: [
+            { postId: 1, title: "으쌰으쌰파티파티" },
+            { postId: 3, title: "React 뿌수기 하실분" },
+            { postId: 4, title: "프로젝트 파트너 찾아요" },
+            { postId: 5, title: "프론트엔드 개발자 모집" },
+            { postId: 6, title: "백엔드 개발자 모집" },
+            { postId: 7, title: "풀스택 개발자 모집" },
+            { postId: 8, title: "디자이너 모집" },
+            { postId: 9, title: "기획자 모집" },
+            { postId: 10, title: "테스터 모집" },
+          ],
+        },
+        refetchOnWindowFocus: false,
+      },
+      {
+        queryKey: ["member", memberId],
+        initialData: {
+          memberProfile: {
+            nickname: "테스트유저",
+            profileImageUrl: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+            position: "프론트엔드",
+          },
+        },
+        refetchOnWindowFocus: false,
+      },
+    ],
+    combine: (results) => {
+      console.log(results);
+      const options = results[0].data as ScoutListApiResponseDto;
+      const {
+        memberProfile: { nickname, profileImageUrl, position },
+      } = results[1].data as MemberProfileApiResponseDto;
+      return { options: options.data, userInfo: { nickname, profileImageUrl, position } };
+    },
+  });
+
+  const { control, handleSubmit } = useForm<InviteMemberRequestDto>({
+    defaultValues: {
+      postId: undefined,
+      memberId: memberId,
+      message: "",
+    },
+    mode: "onSubmit",
+  });
+
+  return (
+    <ModalLayout desktopWidth={430} mobileWidth={320} onClose={() => {}}>
+      <Title>유저 초대하기</Title>
+      <FormBox onSubmit={handleSubmit((data) => console.log(data))}>
+        <FormElement
+          label="초대할 유저"
+          InputComponent={
+            <ScoutUserProfile
+              nickname={results.userInfo.nickname}
+              profileImageUrl={results.userInfo.profileImageUrl}
+              position={results.userInfo.position}
+            />
+          }
+        />
+        <FormElement
+          label="스터디/프로젝트 선택"
+          InputComponent={
+            <RHFDropdown
+              formFieldName="postId"
+              placeholder="스터디/프로젝트 선택"
+              //실 데이터 가져와야함
+              options={results.options.map((option) => option.title)}
+              control={control}
+              errorMessage="스터디/프로젝트를 선택해주세요"
+              isEssential
+            />
+          }
+          isEssential
+        />
+        <FormElement
+          label="초대 메시지"
+          InputComponent={
+            <RHFTextArea formFieldName="message" placeholder="초대 메시지를 입력해주세요" control={control} />
+          }
+        />
+        <Button type="submit" variant="primary">
+          초대하기
+        </Button>
+      </FormBox>
+    </ModalLayout>
+  );
+}
+
+const { color, typography } = DESIGN_TOKEN;
+
+const ModalLayout = styled(DefaultModalLayout)`
+  padding: 4rem 3rem 3rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 6rem;
+`;
+
+const Title = styled.h1`
+  color: ${color.black[1]};
+  ${typography.font20Bold}
+`;
+
+const FormBox = styled.form`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+`;

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -25,7 +25,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
   >({
     queries: [
       {
-        //스카우트를 위한 현재 초대 가능한 스터디/프로젝트 목록 가져오기
+        //TODO: 스카우트를 위한 현재 초대 가능한 스터디/프로젝트 목록 가져오기
         queryKey: ["post", "scout"],
         initialData: {
           data: [
@@ -93,7 +93,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
             <RHFDropdown
               formFieldName="postId"
               placeholder="스터디/프로젝트 선택"
-              //실 데이터 가져와야함
+              //TODO: 실 데이터 가져와야함
               options={results.options.map((option) => option.title)}
               control={control}
               errorMessage="스터디/프로젝트를 선택해주세요"

--- a/co-kkiri/src/components/modals/ScoutModal/index.tsx
+++ b/co-kkiri/src/components/modals/ScoutModal/index.tsx
@@ -17,7 +17,7 @@ interface ScoutModalProps {
 }
 
 type CombinedResults = {
-  options: Option<number>[];
+  options: Option[];
   userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position">;
 };
 
@@ -56,7 +56,7 @@ export default function ScoutModal({ memberId }: ScoutModalProps) {
     ],
     combine: (results) => {
       const rawOptions = results[0].data as ScoutListApiResponseDto;
-      const options = rawOptions.data.map<Option<number>>((option) => ({ value: option.postId, label: option.title }));
+      const options = rawOptions.data.map<Option>((option) => ({ value: option.postId, label: option.title }));
       const {
         memberProfile: { nickname, profileImageUrl, position },
       } = results[1].data as MemberProfileApiResponseDto;

--- a/co-kkiri/src/components/modals/ScoutModal/types.ts
+++ b/co-kkiri/src/components/modals/ScoutModal/types.ts
@@ -1,0 +1,7 @@
+import { Option } from "@/components/commons/Form/RHFDropdown";
+import { MemberProfile } from "@/lib/api/member/type";
+
+export type CombinedResults = {
+  options: Option[];
+  userInfo: Pick<MemberProfile, "nickname" | "profileImageUrl" | "position">;
+};

--- a/co-kkiri/src/components/modals/ScoutModal/utils.ts
+++ b/co-kkiri/src/components/modals/ScoutModal/utils.ts
@@ -1,0 +1,20 @@
+import { InviteMemberRequestDto } from "@/lib/api/post/type";
+import { CombinedResults } from "./types";
+
+export const mapSubmitData = (queryData: CombinedResults, formData: InviteMemberRequestDto) => {
+  const { postId, memberId, message } = formData;
+  const responseData: InviteMemberRequestDto = {
+    postId: postId,
+    memberId: memberId,
+    message: message,
+  };
+
+  // 데이터 매핑처리
+  if (message.trim() === "") {
+    responseData.message = `
+            ${queryData.userInfo.nickname}님, 안녕하세요? 🖐️\n 제가 진행 중인 "${queryData.options.find((option) => option.value === postId)?.label}" 에서 함께 공부하고 성장할 동료분들을 모시고있습니다. \n관심 있으시면 편하게 연락주세요! 🥰 
+            `.trim();
+  }
+
+  return responseData;
+};

--- a/co-kkiri/src/constants/dropDown.ts
+++ b/co-kkiri/src/constants/dropDown.ts
@@ -5,7 +5,7 @@ const { MY_PAGE, MY_STUDY } = ROUTER_PATH;
 
 type DropdownInfo = {
   [key: string]: {
-    [key: string]: Array<Option<unknown>>;
+    [key: string]: Array<Option>;
   };
 };
 

--- a/co-kkiri/src/constants/dropDown.ts
+++ b/co-kkiri/src/constants/dropDown.ts
@@ -1,6 +1,110 @@
+import { Option } from "@/components/commons/Form/RHFDropdown";
 import { ROUTER_PATH } from "@/lib/path";
 
 const { MY_PAGE, MY_STUDY } = ROUTER_PATH;
+
+type DropdownInfo = {
+  [key: string]: {
+    [key: string]: Array<Option<unknown>>;
+  };
+};
+
+export const DROPDOWN_FORM_INFO: DropdownInfo = {
+  user: {
+    position: [
+      { label: "풀스택", value: "풀스택" },
+      { label: "프론트엔드", value: "프론트엔드" },
+      { label: "백엔드", value: "백엔드" },
+      { label: "디자이너", value: "디자이너" },
+      { label: "IOS", value: "IOS" },
+      { label: "안드로이드", value: "안드로이드" },
+      { label: "데브옵스", value: "데브옵스" },
+    ],
+    career: [
+      { label: "신입", value: 0 },
+      { label: "1년차", value: 1 },
+      { label: "2년차", value: 2 },
+      { label: "3년차", value: 3 },
+      { label: "4년차", value: 4 },
+      { label: "5년차", value: 5 },
+      { label: "5년차 이상", value: 999 },
+    ],
+  },
+  recruitment: {
+    progressPeriod: [
+      { label: "협의 후 결정", value: null },
+      { label: "1주", value: "1주" },
+      { label: "2주", value: "2주" },
+      { label: "3주", value: "3주" },
+      { label: "1개월", value: "1개월" },
+      { label: "2개월", value: "2개월" },
+      { label: "3개월", value: "3개월" },
+      { label: "4개월", value: "4개월" },
+      { label: "5개월", value: "5개월" },
+      { label: "6개월", value: "6개월" },
+      { label: "6개월 이상", value: "6개월 이상" },
+    ],
+    progressWay: [
+      { label: "온라인", value: "온라인" },
+      { label: "오프라인", value: "오프라인" },
+      { label: "온/오프라인", value: "온/오프라인" },
+    ],
+    capacity: [
+      { label: "인원 미정", value: null },
+      { label: "1명", value: 1 },
+      { label: "2명", value: 2 },
+      { label: "3명", value: 3 },
+      { label: "4명", value: 4 },
+      { label: "5명", value: 5 },
+      { label: "6명", value: 6 },
+      { label: "7명", value: 7 },
+      { label: "8명", value: 8 },
+      { label: "9명", value: 9 },
+      { label: "10명 이상", value: 999 },
+    ],
+    contactWay: [
+      { label: "기타", value: null },
+      { label: "카카오 오픈톡", value: "카카오 오픈톡" },
+      { label: "이메일", value: "이메일" },
+      { label: "구글폼", value: "구글폼" },
+    ],
+  },
+};
+
+export const DROPDOWN_FILTER_INFO: DropdownInfo = {
+  filter: {
+    position: [
+      { label: "전체", value: "전체" },
+      { label: "프론트엔드", value: "프론트엔드" },
+      { label: "백엔드", value: "백엔드" },
+      { label: "디자이너", value: "디자이너" },
+      { label: "IOS", value: "IOS" },
+      { label: "안드로이드", value: "안드로이드" },
+      { label: "데브옵스", value: "데브옵스" },
+    ],
+    progressWay: [
+      { label: "전체", value: "전체" },
+      { label: "온라인", value: "온라인" },
+      { label: "오프라인", value: "오프라인" },
+      { label: "온/오프라인", value: "온/오프라인" },
+    ],
+  },
+  sort: {
+    sort: [
+      { label: "최신순", value: "LATEST" },
+      { label: "마감순", value: "BYDEADLINE" },
+      { label: "조회순", value: "BYVIEW" },
+    ],
+  },
+  popover: {
+    popover: [
+      { label: "나의 스터디", value: MY_STUDY },
+      { label: "마이페이지", value: MY_PAGE },
+      { label: "로그아웃", value: "" },
+    ],
+  },
+};
+
 
 export const DROPDOWN_INFO = {
   user: {

--- a/co-kkiri/src/lib/api/member/type.ts
+++ b/co-kkiri/src/lib/api/member/type.ts
@@ -1,5 +1,5 @@
 // 유저 프로필 조회
-type MemberProfile = {
+export type MemberProfile = {
   memberId: number;
   nickname: string;
   profileImageUrl: string;

--- a/co-kkiri/src/lib/api/post/type.ts
+++ b/co-kkiri/src/lib/api/post/type.ts
@@ -113,14 +113,14 @@ export type StudyManagementApiResponseDto = {
   stacks: string[];
 };
 
-type ScoutPost = {
+export type ScoutPost = {
   postId: number;
   title: string;
 };
 
 /**스카우트 스터디/프로젝트 목록 -백엔드 확인요망*/
 export type ScoutListApiResponseDto = {
-  content: ScoutPost[];
+  data: ScoutPost[];
   // meta: Pageable  페이지네이션 정보, 추후 추가 예정
 };
 

--- a/co-kkiri/src/lib/mock/scout/scoutList.ts
+++ b/co-kkiri/src/lib/mock/scout/scoutList.ts
@@ -1,0 +1,28 @@
+import { MemberProfileApiResponseDto } from "@/lib/api/member/type";
+import { ScoutListApiResponseDto } from "@/lib/api/post/type";
+
+export const scoutList: ScoutListApiResponseDto = {
+  data: [
+    { postId: 1, title: "으쌰으쌰파티파티" },
+    { postId: 3, title: "React 뿌수기 하실분" },
+    { postId: 4, title: "프로젝트 파트너 찾아요" },
+    { postId: 5, title: "프론트엔드 개발자 모집" },
+    { postId: 6, title: "백엔드 개발자 모집" },
+    { postId: 7, title: "백엔드 개발자 모집" },
+    { postId: 8, title: "디자이너 모집" },
+    { postId: 9, title: "기획자 모집" },
+    { postId: 10, title: "테스터 모집" },
+  ],
+};
+
+export const scoutMember: MemberProfileApiResponseDto = {
+  memberProfile: {
+    nickname: "테스트유저",
+    profileImageUrl: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+    position: "프론트엔드",
+    memberId: 1,
+    career: 3,
+    stacks: ["React", "TypeScript"],
+    gauge: 3,
+  },
+};


### PR DESCRIPTION
### 📌요구사항
- [x] FormElement 로직 구현
- [x] 유저 스카우트 후 초대 모달 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

<br/>

# FormElement
## 개요
>FormElement는 폼 개발의 편의성과 확장성을 높이는 범용 컴포넌트입니다.
기존 컴포넌트를 폼 관리 시스템에 쉽게 통합하고자 하고싶어서 만들었습니다. 
핵심은 `FormFieldProps`인터페이스를 준수하면 어떤 컴포넌트든 FormElement에 통합할 수 있다는 점입니다
## 개발 목적

- 폼 요소 개발 시간과 노력을 줄이고 싶었습니다
- 폼의 유지보수성과 확장성을 높이고 싶었습니다
- 코드 중복을 줄이고 재사용 가능한 컴포넌트로 개발 효율성을 높이고 싶었습니다
<br/>

### `FormFieldProps`
- FormFieldComponent가 FormElement에 의해 관리되기 위해 필요한 **프로퍼티**를 정의
```tsx
interface FormFieldProps<ValueType> {
// 사용자 입력 시 호출되는 함수,  값이 변경되면 실행되어야 함
  onChange: (value: ValueType) => void;
// 폼 필드의 현재 값
  value: ValueType; 
// 유효성 검사 결과를 나타내는 불리언 값
  isError?: boolean;
// 사용자에게 제공되는 추가 정보나 에러 메시지 정의
  helperText?: string;
}
```
<br/>

### FormFieldComponent 내에 컴포넌트를 넣고싶으면 따라야 할 가이드라인
**1. 인터페이스 준수**
- 기존 컴포넌트를 FormElement로 통합하려면 먼저 `FormFieldProps`인터페이스를 준수하도록 수정
- 이렇게 하면 컴포넌트가 FormElement 프로퍼티를 올바르게 받아들이고 사용할 수 있음

**2. 상태 관리 및 이벤트 핸들링**
- `onChange`, `value`프로퍼티를 사용하여 컴포넌트의 상태 관리와 이벤트 핸들링을 구현
- 사용자 입력에 따라 `onChange`함수를 호출하여 상위 컴포넌트 상태를 업데이트

**3. 에러 표시 및 도움말 제공**
- `isError`프로퍼티로 에러 상태를 확인하고, 에러가 있다면 사용자에게 피드백을 제공
- `helperText`를 사용하여 에러 메시지나 추가 정보를 사용자에게 제공

<br/>

## 간단 사용 예시
```tsx
<FormElement label="초대할 유저" FormFieldComponent={<ScoutUserProfile {...values.userInfo} />} />
<Wrapper>
  <FormElement
    label="스터디/프로젝트 선택"
    FormFieldComponent={
      <RHFDropdown
        formFieldName="postId"
        placeholder="스터디/프로젝트 선택"
        //TODO: 실 데이터 가져와야함
        options={values.options}
        control={control}
        errorMessage="스터디/프로젝트를 선택해주세요"
        isEssential
      />
    }
    isEssential
  />
```

## FormElement의 형태만 쓰고싶다면?
![image](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/62014235-2b37-4b36-b694-5a9ddd267271)

```tsx
<FormElement label="test2" isEssential FormFieldComponent={<p>야홍</p>} />
```


---
<br/>
<br/>

# `RHF...`와 `Form...` 컴포넌트의 차이?
## 핵심
>둘 다 모두 FormElement 내의 폼 요소로써 동작하기 위해 감싼 컴포넌트입니다

## 차이
### `Form...` 컴포넌트
```tsx
export default function FormDropdown({
  placeholder,
  value,
  options,
  onChange,
  isError,
  helperText,
}: FormDropdownProps) {
  return (
    <Container>
      <Dropdown
        placeholder={placeholder}
        selectedOption={value.label}
        options={options}
        onSelect={onChange}
        isError={isError}
      />
      <HelperText>{helperText}</HelperText>
    </Container>
  );
}
```
- `FormFieldProps`를 준수한 컴포넌트
- 필요에따라 기본 컴포넌트에서 `FormFieldProps`를 준수하도록 **감싸서** 만들 수 있음
- 폼에서 사용될 수 있음

### `RHF...` 컴포넌트
```tsx
export default function RHFDropdown<ControlType extends FieldValues>({
  placeholder,
  options,
  formFieldName,
  control,
  isEssential,
  errorMessage,
}: RHFDropdownProps<ControlType>) {
  return (
    <Controller
      name={formFieldName}
      control={control}
      rules={isEssential ? { required: errorMessage || "필수 입력사항입니다" } : {}}
      render={({ field, fieldState }) => (
        <FormDropdown
          placeholder={placeholder}
          value={options.find((option) => option.value === field.value) || { label: "", value: "" }}
          options={options}
          onChange={(option: Option) => {
            field.onChange(option.value);
          }}
          isError={fieldState.invalid}
          helperText={fieldState.error?.message}
        />
      )}
    />
  );
}
```
- `Form...`컴포넌트에 `React Hook Form`의 기능을 사용하기 위해 `Controller`로 감싼 컴포넌트
- React Hook Form의 기능을 쓰기 때문에 유효성 검사와, 값 관리를 보다 쉽게 할 수 있음
- 참고로 앞에 RHF를 붙인 것은, 말고는 더 좋은 이름이 생각나지 않아서..

<br/>
<br/>

-----
# 주요 변경점
## Dropdown이 대폭 변경되었습니다
>이로인해, 사용하는 곳에서 모두 오류가 날 예정입니다
양이 많아, 머지된 후 Bug 이슈 파서 모두 고치겠습니다

```tsx
interface DropdownProps {
  placeholder: string;
  selectedOption?: string | null;
  options: Option[];
  isError?: boolean;
  onSelect: (option: Option) => void;
  dropdownRef?: React.RefCallback<HTMLButtonElement>;
}
```

### 더이상 `options`를 `string[]`으로 받지 않음
- 이제 options와 onSelect는 `Option`이라는 type 기준으로 동작
>`Option`이 뭔가요?
```tsx
export type Option = {
  label: string;
  value: unknown;
};
```

- Dropdown같은 컴포넌트는 보여주는 값과, 실제 담겨있는 값이 다를 수 있음
- 이에따라 Dropdown이 label외에도 value를 가지고 있어야 하여 생긴 구조
- 값을 활용해야할 때는, `onSelect`의 `option` 인자에서 `value`를 가지고 와서 활용하시면 됨

### 변경 이유...
>기존에는 string[]이 전달되면, `onSelect`에서는 선택한 option을 기준으로 `options` 배열에서 `findIndex`로 `Index`값을 찾아왔습니다. 그리고 그 `Index`값을 다시 활용해 `values` 배열에서 실제 `value`를 찾아오는 과정을 진행했습니다.
하지만 이러다보니, `options`에 중복된 값이 들어있는 경우, 원하지않는 `Index`값이 전달되는 경우가 생겼습니다.
보다 체계적인 값의 관리가 필요하다고 생각되어, 객체 형태를 선택하게 되었습니다.

## 이에따라 `constant`도 변경되었습니다
### 이전
```tsx
export const DROPDOWN_INFO = {
  user: {
    position: {
      defaultValue: "포지션",
      options: ["풀스택", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
      values: ["풀스택", "프론트엔드", "백엔드", "디자이너", "IOS", "안드로이드", "데브옵스"],
    },
```
### 현재
```tsx
export const DROPDOWN_FORM_INFO: DropdownInfo = {
  user: {
    position: [
      { label: "풀스택", value: "풀스택" },
      { label: "프론트엔드", value: "프론트엔드" },
      { label: "백엔드", value: "백엔드" },
      { label: "디자이너", value: "디자이너" },
      { label: "IOS", value: "IOS" },
      { label: "안드로이드", value: "안드로이드" },
      { label: "데브옵스", value: "데브옵스" },
    ],
//...
```

- `Option`의 구조를 따르게끔 변경됨
- 이전의 `DROPDOWN_INFO` 상수는 아직 삭제하지 않음
- 모든 전환이 완료된 후에 안전하게 삭제할 예정

### 📌스크린샷 / 테스트결과 (선택)
![Form](https://github.com/co-KKIRI/FE_co-KKIRI/assets/66313756/cc30ac5c-c053-489e-a167-bad1d3499bd7)


### 📌이슈 번호
