### PR TITLE
Refactor: 로딩 시 스크랩 버튼 막기 및 useScrapMutation 훅 제작 등

### DIFF
--- a/co-kkiri/src/components/commons/Card/Card.styled.ts
+++ b/co-kkiri/src/components/commons/Card/Card.styled.ts
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import DESIGN_TOKEN from "@/styles/tokens";
-import CardCornerButton from "../CardCornerButton";
 import { Pages } from "@/types/pagesTypes";
+import Header from "./Header";
 
 interface PageProp {
   $page: Pages;
@@ -73,37 +73,15 @@ export const UpperBox = styled.div<PageProp>`
   ${({ $page }) => {
     switch ($page) {
       case "home":
-        return `padding: 1rem 2rem 1.8rem;`;
+        return `padding: 2rem 2rem 1.8rem;`;
       default:
         return `padding: 0.5rem 2rem 1.5rem;`;
     }
   }};
 `;
 
-const paddingBottomByPage = ($page: Pages) => {
-  switch ($page) {
-    case "home":
-      return "0.8rem";
-    default:
-      return "1.2rem";
-  }
-};
-
-export const HeaderWrapper = styled.header<PageProp>`
-  ${({ $page }) => `padding-bottom: ${paddingBottomByPage($page)};`}
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-export const HeaderPadding = styled.div<PageProp>`
-  ${({ $page }) => ($page === "home" ? `padding-top: 1rem; padding-bottom: 0.4rem;` : "")}
-`;
-
-export const HomeCardCornerButton = styled(CardCornerButton)`
-  img {
-    width: 2.8rem;
-  }
+export const HeaderSection = styled(Header)`
+  padding-bottom: 1.2rem;
 `;
 
 export const ContentWrapper = styled.main`

--- a/co-kkiri/src/components/commons/Card/Header.tsx
+++ b/co-kkiri/src/components/commons/Card/Header.tsx
@@ -6,11 +6,12 @@ import { formatDate } from "@/utils/formatDate";
 interface HeaderProps {
   deadline: string;
   progressWay: string;
+  className?: string;
 }
 
-export default function Header({ deadline, progressWay }: HeaderProps) {
+export default function Header({ deadline, progressWay, className }: HeaderProps) {
   return (
-    <Container>
+    <Container className={className}>
       <span>{`${formatDate(deadline)} 마감`}</span>
       <div></div>
       <span>{progressWay}</span>

--- a/co-kkiri/src/components/commons/Card/index.tsx
+++ b/co-kkiri/src/components/commons/Card/index.tsx
@@ -63,12 +63,7 @@ export default function Card({ page = "home", cardData }: CardProps) {
           </S.TypeWrapper>
         )}
         <S.UpperBox $page={page}>
-          <S.HeaderWrapper $page={page}>
-            <S.HeaderPadding $page={page}>
-              <Header deadline={recruitEndAt} progressWay={progressWay} />
-            </S.HeaderPadding>
-            {page === "home" && <S.HomeCardCornerButton isScraped={isScraped} postId={postId} />}
-          </S.HeaderWrapper>
+          <S.HeaderSection deadline={recruitEndAt} progressWay={progressWay} />
           <S.ContentWrapper>
             <Title title={title} />
             <Positions positions={position || positions} variant="card" page={page} />

--- a/co-kkiri/src/constants/hotAndNewList.ts
+++ b/co-kkiri/src/constants/hotAndNewList.ts
@@ -3,8 +3,8 @@ import { ROUTER_PATH } from "@/lib/path";
 const { STUDY_LIST_PATH } = ROUTER_PATH;
 
 export const HOT_AND_NEW_LIST = {
-  newStudyLists: { title: "New! 스터디", path: STUDY_LIST_PATH },
+  newStudyLists: { title: "💥 New! 스터디 💥", path: STUDY_LIST_PATH },
   hotStudyLists: { title: "🎊 인기 스터디 🎊", path: STUDY_LIST_PATH },
   newProjectLists: { title: "✨ 신규 프로젝트 ✨", path: STUDY_LIST_PATH },
-  hotProjectLists: { title: "인기 프로젝트", path: STUDY_LIST_PATH },
+  hotProjectLists: { title: "🎉 인기 프로젝트 🎉", path: STUDY_LIST_PATH },
 };

--- a/co-kkiri/src/hooks/useMutation/useScrapMutation.ts
+++ b/co-kkiri/src/hooks/useMutation/useScrapMutation.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { scrapAdd, scrapCancel } from "@/lib/api/scrap";
+import { useToggle } from "usehooks-ts";
+
+function useScrapMutations(postId: number, isScraped: boolean) {
+  const queryClient = useQueryClient();
+  const [isScrapedValue, toggle] = useToggle(isScraped);
+
+  const ScrapMutation = useMutation({
+    mutationFn: () => scrapAdd(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["homeCardList"] });
+      queryClient.invalidateQueries({ queryKey: ["/my-page/scrap/list"] });
+      queryClient.invalidateQueries({ queryKey: ["postDetail", postId] });
+      toggle();
+    },
+  });
+
+  const CancelScrapMutation = useMutation({
+    mutationFn: () => scrapCancel(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["homeCardList"] });
+      queryClient.invalidateQueries({ queryKey: ["/my-page/scrap/list"] });
+      queryClient.invalidateQueries({ queryKey: ["postDetail", postId] });
+      toggle();
+    },
+  });
+
+  return { ScrapMutation, CancelScrapMutation, isScrapedValue };
+}
+
+export default useScrapMutations;


### PR DESCRIPTION
### 📌요구사항
- [x] 리퀘스트 isPending true 시 스크랩 버튼 클릭 막음
- [x] useScrapMutation 훅 제작

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
- Debounce 또한 일정시간 동안 리퀘스트를 막는 것임
  - detail 페이지에서 scrap 또는 신청하기 버튼 클릭 시 리퀘스트를 요청해야 하므로 적절한 방법이 아님
  - 조회수 카운트 문제는 백엔드 단에서 해결해야 할 것 같음
  - 멘토님께 여쭤봅시다!

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/co-KKIRI/FE_co-KKIRI/assets/117327533/8fd931b4-142d-42e0-8c58-c7beb5133045

### 📌이슈 번호
