### PR TITLE
Feat: Detail 페이지 댓글 infinite query 구현, 지원하기 취소 api 연결, apiRequest함수 에러처리 리팩토링

### DIFF
--- a/co-kkiri/src/components/domains/detail/Comments/CommentForm.tsx
+++ b/co-kkiri/src/components/domains/detail/Comments/CommentForm.tsx
@@ -21,6 +21,11 @@ export default function CommentForm() {
       onSuccess: () => {
         setContent("");
       },
+      onError: (error) => {
+        if (error.name === "Unauthorized") {
+          return; //토스트
+        }
+      },
     });
   };
 

--- a/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
+++ b/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
@@ -22,25 +22,19 @@ export default function StatusBasedButton({ postApplyStatus, postId, className }
 
   const { applyMutation } = usePostMutation();
 
-  // const memberId = 15; //임시
-  // const applicant = { memberId };
-
   const handleConfirmAgreeClick = () => {
-    // switch (postApplyStatus) {
-    //   case "APPLIED":
-    //     confirmToggle();
-    //     break;
-    //   case "NOT_APPLIED":
-    //     applyMutation.mutate(
-    //       { postId, data: applicant },
-    //       {
-    //         onSuccess: () => {
-    //           confirmToggle();
-    //         },
-    //       },
-    //     );
-    //     break;
-    // }
+    switch (postApplyStatus) {
+      case "APPLIED":
+        confirmToggle();
+        break;
+      case "NOT_APPLIED":
+        applyMutation.mutate(postId, {
+          onSuccess: () => {
+            confirmToggle();
+          },
+        });
+        break;
+    }
   };
 
   const handleModal = () => {

--- a/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
+++ b/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
@@ -21,21 +21,24 @@ export default function StatusBasedButton({ postApplyStatus, postId, className }
   const { isOpen: isInviteResponseOpen, openToggle: inviteResponseToggle } = useOpenToggle();
   const [confirmType, setConfirmType] = useState<ConfirmType>("apply");
 
-  const { applyMutation } = usePostMutation();
+  const { applyMutation, cancelMutation } = usePostMutation();
 
   const handleConfirmAgreeClick = () => {
     switch (postApplyStatus) {
       case "APPLIED":
-        confirmToggle();
+        cancelMutation.mutate(postId, {
+          onSuccess: () => {}, //토스트 추가
+          onSettled: () => {
+            confirmToggle();
+          },
+        });
         break;
       case "NOT_APPLIED":
         applyMutation.mutate(postId, {
-          onSuccess: () => {
-            return;
-          },
+          onSuccess: () => {}, //토스트 추가
           onError: (error) => {
             if (error.name === "Unauthorized") {
-              return; //토스트
+              return; //토스트 추가
             }
           },
           onSettled: () => {

--- a/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
+++ b/co-kkiri/src/components/domains/detail/StatusBasedButton.tsx
@@ -8,6 +8,7 @@ import { statusButtonConfig, StatusButtonConfig } from "@/constants/statusButton
 import { ConfirmType } from "@/components/modals/ConfirmModal";
 import { PostApplyStatus } from "@/lib/api/post/type";
 import usePostMutation from "@/hooks/useMutation/usePostMutation";
+import { Variable } from "lucide-react";
 
 interface MappedButtonProps {
   postApplyStatus: PostApplyStatus;
@@ -30,6 +31,14 @@ export default function StatusBasedButton({ postApplyStatus, postId, className }
       case "NOT_APPLIED":
         applyMutation.mutate(postId, {
           onSuccess: () => {
+            return;
+          },
+          onError: (error) => {
+            if (error.name === "Unauthorized") {
+              return; //토스트
+            }
+          },
+          onSettled: () => {
             confirmToggle();
           },
         });

--- a/co-kkiri/src/components/domains/scout/ScoutCards.tsx
+++ b/co-kkiri/src/components/domains/scout/ScoutCards.tsx
@@ -63,7 +63,7 @@ const Wrapper = styled.div<{ $isSidebarOpenNarrow: boolean }>`
   }
 
   ${mediaQueries.mobile} {
-    grid-template-columns: repeat(1, 32rem);
+    grid-template-columns: repeat(1, 1fr);
     gap: 2rem;
   }
 `;

--- a/co-kkiri/src/hooks/useMutation/usePostMutation.ts
+++ b/co-kkiri/src/hooks/useMutation/usePostMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { createPost, modifyPost, deletePost, applyPost } from "@/lib/api/post";
+import { createPost, modifyPost, deletePost, applyPost, cancelApplyPost } from "@/lib/api/post";
 import { RecruitApiRequestDto } from "@/lib/api/post/type";
 
 interface ModifyPostPayload {
@@ -35,5 +35,11 @@ export default function usePostMutation() {
     onError: (error) => console.error(error, error.message),
   });
 
-  return { uploadMutation, editMutation, deleteMutation, applyMutation };
+  const cancelMutation = useMutation({
+    mutationFn: (postId: number) => cancelApplyPost(postId),
+    onSuccess: (_, postId) => queryClient.invalidateQueries({ queryKey: ["postDetail", postId] }),
+    onError: (error) => console.error(error, error.message),
+  });
+
+  return { uploadMutation, editMutation, deleteMutation, applyMutation, cancelMutation };
 }

--- a/co-kkiri/src/hooks/useMutation/usePostMutation.ts
+++ b/co-kkiri/src/hooks/useMutation/usePostMutation.ts
@@ -1,15 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createPost, modifyPost, deletePost, applyPost } from "@/lib/api/post";
-import { ApplyPostApiRequestDto, RecruitApiRequestDto } from "@/lib/api/post/type";
+import { RecruitApiRequestDto } from "@/lib/api/post/type";
 
 interface ModifyPostPayload {
   postId: number;
   data: RecruitApiRequestDto;
-}
-
-interface ApplyPostPayload {
-  postId: number;
-  data: ApplyPostApiRequestDto;
 }
 
 export default function usePostMutation() {
@@ -35,8 +30,8 @@ export default function usePostMutation() {
   });
 
   const applyMutation = useMutation({
-    mutationFn: ({ postId, data }: ApplyPostPayload) => applyPost(postId, data),
-    onSuccess: (_, { postId }) => queryClient.invalidateQueries({ queryKey: ["postDetail", postId] }),
+    mutationFn: (postId: number) => applyPost(postId),
+    onSuccess: (_, postId) => queryClient.invalidateQueries({ queryKey: ["postDetail", postId] }),
     onError: (error) => console.error(error, error.message),
   });
 

--- a/co-kkiri/src/lib/api/address.ts
+++ b/co-kkiri/src/lib/api/address.ts
@@ -22,6 +22,8 @@ export const postAddress = {
   postId: (postId: number) => `/post/${postId}`,
   //get, post
   apply: (postId: number) => `/post/${postId}/apply`,
+  //delete
+  cancel: (postId: number) => `/post/${postId}/apply/cancel`,
   //patch
   modify: (postId: number) => `/post/${postId}/modify`,
   //get

--- a/co-kkiri/src/lib/api/axios.ts
+++ b/co-kkiri/src/lib/api/axios.ts
@@ -33,7 +33,11 @@ export async function apiRequest<T, U>(
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      throw error;
+      const errorMessage = error.response.data.message;
+      const errorName = error.response.statusText;
+      const axiosError = new Error(errorMessage);
+      axiosError.name = errorName;
+      throw axiosError;
     } else {
       console.error(`${method} Error : `, error);
       throw error;

--- a/co-kkiri/src/lib/api/post/index.ts
+++ b/co-kkiri/src/lib/api/post/index.ts
@@ -38,6 +38,9 @@ export const deletePost = (postId: number) => apiRequest("delete", postAddress.p
 /** 스터디 지원하기 */
 export const applyPost = (postId: number) => apiRequest("post", postAddress.apply(postId));
 
+/** 스터디 지원 취소하기 */
+export const cancelApplyPost = (postId: number) => apiRequest("delete", postAddress.cancel(postId));
+
 /** 지원한 유저 목록 가져오기
  *
  *@param {number} postId

--- a/co-kkiri/src/lib/api/post/index.ts
+++ b/co-kkiri/src/lib/api/post/index.ts
@@ -3,7 +3,6 @@ import { apiRequest } from "../axios";
 import {
   AppliedMemberListApiRequestDto,
   AppliedMemberListApiResponseDto,
-  ApplyPostApiRequestDto,
   InviteMemberRequestDto,
   ListApiRequestDto,
   ListApiResponseDto,
@@ -37,8 +36,7 @@ export const modifyPost = (postId: number, data: RecruitApiRequestDto) =>
 export const deletePost = (postId: number) => apiRequest("delete", postAddress.postId(postId));
 
 /** 스터디 지원하기 */
-export const applyPost = (postId: number, data: ApplyPostApiRequestDto) =>
-  apiRequest("post", postAddress.apply(postId), data);
+export const applyPost = (postId: number) => apiRequest("post", postAddress.apply(postId));
 
 /** 지원한 유저 목록 가져오기
  *

--- a/co-kkiri/src/lib/api/post/type.ts
+++ b/co-kkiri/src/lib/api/post/type.ts
@@ -76,11 +76,6 @@ export type PostDetailApiResponseDto = {
   postApplyStatus: PostApplyStatus;
 };
 
-/**스터디 지원 */
-export type ApplyPostApiRequestDto = {
-  memberId: number;
-};
-
 /**스터디 지원 목록 */
 export type AppliedMemberListApiRequestDto = PaginationOptions;
 

--- a/co-kkiri/src/pages/Detail/index.tsx
+++ b/co-kkiri/src/pages/Detail/index.tsx
@@ -35,7 +35,7 @@ export default function Detail() {
     <S.Container>
       <S.Box>
         <S.GoBackButton />
-        <S.ShareAndScrapButton isScraped={isScraped} postId={Number(id)} />
+        <S.ShareAndScrapButton isScraped={isScraped} postId={postId} />
         <S.PostSection postDetails={postDetails} postApplyStatus={postApplyStatus} />
         <S.DetailCardSection cardRef={cardRef} postDetails={postDetails} />
         <S.CommentsSection postId={postId} />

--- a/co-kkiri/src/pages/Detail/index.tsx
+++ b/co-kkiri/src/pages/Detail/index.tsx
@@ -16,7 +16,13 @@ export default function Detail() {
     isPending,
     isError,
     error,
-  } = useQuery({ queryKey: ["postDetail", postId], queryFn: () => getPostDetail(postId) });
+  } = useQuery({
+    queryKey: ["postDetail", postId],
+    queryFn: () => getPostDetail(postId),
+    retry: 0,
+    refetchOnWindowFocus: false,
+    staleTime: 60 * 1000,
+  });
 
   const cardHeight = useComponentHeight<PostDetailApiResponseDto | undefined>(detailData, cardRef, 407);
 

--- a/co-kkiri/src/pages/Scout/styled.tsx
+++ b/co-kkiri/src/pages/Scout/styled.tsx
@@ -30,6 +30,10 @@ export const Container = styled.div`
 export const Box = styled.div`
   display: flex;
   flex-direction: column;
+
+  ${mediaQueries.mobile} {
+    width: 100%;
+  }
 `;
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
### 📌요구사항
- [x] 댓글 infinite query 구현
- [x] 지원하기 취소 api 연결
- [x] apiRequest함수 에러처리 리팩토링
- [x] 지원하기 api 수정 

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)
토스트 완성되면 연결할게요!!!😊

commentCount는 댓글 삭제로직이 반영이 되지 않은것 같아요. 저는 다른 방법으로 댓글 갯수를 얻고 있긴 한데 카드 컴포넌트에서도 commentCount가 쓰여서  api이슈에 남겨뒀어요. 현재 카드에 표시되는 댓글 수는 기존 댓글보다 많을수 있으니 참고 부탁드려용
 
### 📌스크린샷 / 테스트결과 (선택)

### 다음페이지가 있을경우 더보기 버튼이 보입니다.

https://github.com/co-KKIRI/FE_co-KKIRI/assets/148737398/8067ab8b-80c6-4381-ab83-1bab988b8526


### 다음 페이지가 없을 경우 더보기버튼이 표시되지 않습니당 

![스크린샷 2024-03-29 오전 2 07 50](https://github.com/co-KKIRI/FE_co-KKIRI/assets/148737398/93563613-13bd-4a87-b553-899b923f4847)

### 📌이슈 번호
close #205